### PR TITLE
kvmtool: 2021-07-16 -> 2021-08-31

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -130,9 +130,7 @@
               microvm = import ./pkgs/microvm-command.nix {
                 pkgs = nixpkgs.legacyPackages.${system};
               };
-              kvmtool = import ./pkgs/kvmtool.nix {
-                pkgs = nixpkgs.legacyPackages.${system};
-              };
+              kvmtool = nixpkgs.legacyPackages.${system}.callPackage ./pkgs/kvmtool.nix {};
             };
 
         checks =

--- a/pkgs/kvmtool.nix
+++ b/pkgs/kvmtool.nix
@@ -1,24 +1,37 @@
-{ pkgs }:
-
-with pkgs;
-
+{ stdenv, fetchgit, lib, zlib, libaio, libbfd }:
 stdenv.mkDerivation {
   pname = "kvmtool";
-  version = "2021-07-16";
+  version = "2021-08-31";
 
   src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/linux/kernel/git/will/kvmtool.git";
-    sha256 = "0gp7gp5zy0g074brph06azqyq862f3cnww3iscvpcl7q2b9jh38k";
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/will/kvmtool.git";
+    rev = "2e7380db438defbc5aa24652fe10b7bf99822355";
+    sha256 = "sha256-QhT0znxlLWhFtN2DiwU0Zl3IYJDpynX8DYBHVTxy8iU=";
   };
 
   buildInputs = [
-    zlib libaio
-    # FIXME: not detecting: libbfd
+    zlib libaio libbfd
   ];
-  buildPhase = "make -j$NIX_BUILD_CORES";
 
-  installPhase = ''
-    mkdir -p $out/bin
-    cp -a lkvm $out/bin
+  # libfd wants that
+  NIX_CFLAGS_COMPILE = "-DPACKAGE=1 -DPACKAGE_VERSION=1";
+  enableParallelBuilding = true;
+  buildPhase = ''
+    runHook preBuild
+    # the SHELL passed to the make in our normal build phase is breaking feature detection
+    make -j$NIX_BUILD_CORES
+    runHook postBuild
   '';
+  installPhase = ''
+    runHook preInstall
+    make install -j$NIX_BUILD_CORES prefix=${placeholder "out"}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A lightweight tool for hosting KVM guests";
+    homepage =
+      "https://git.kernel.org/pub/scm/linux/kernel/git/will/kvmtool.git/tree/README";
+    license = licenses.gpl2;
+  };
 }


### PR DESCRIPTION
- fix linking against bfd
- pin git revison to avoid breaking hash
- more secure https over git protocol for fetching
- allow to override dependencies by using callPackage