### PR TITLE
Firecracker: root-drive must be suffixed with :ro

### DIFF
--- a/nixos-modules/microvm/hypervisor/firecracker.nix
+++ b/nixos-modules/microvm/hypervisor/firecracker.nix
@@ -28,7 +28,7 @@ in {
           "-c" (toString vcpu)
           "--kernel=${config.system.build.kernel.dev}/vmlinux"
           "--kernel-opts=console=ttyS0 noapic reboot=k panic=1 pci=off nomodules ${toString config.microvm.kernelParams}"
-          "--root-drive=${rootDisk}"
+          "--root-drive=${rootDisk}:ro"
         ] ++
         (if socket != null then [ "-s" socket ] else []) ++
         map ({ image, ... }:


### PR DESCRIPTION
Per the firectl docs, read-only block devices must be suffixed with a `:ro` after the rootfs file path. Without this, we cannot attach a rootfs that's built inside the nix store. Attempting to run a VM that has its rootfs inside a NixOS /nix/store (that's mounted read-only) results is firecracker errors:

```
[root@host:~]# ./result/bin/microvm-run                                          
INFO[0000] Called startVMM(), setting up a VMM on control.socket                        
INFO[0000] VMM logging disabled.                                                                                                                                                
INFO[0000] VMM metrics disabled.                                                                                                                                                
INFO[0000] refreshMachineConfiguration: [GET /machine-config][200] getMachineConfigurationOK  &{CPUTemplate: MemSizeMib:0xc00026d908 Smt:0xc00026d913 TrackDirtyPages:false Vcpu
Count:0xc00026d900}                                                                                                                                                             
INFO[0000] PutGuestBootSource: [PUT /boot-source][204] putGuestBootSourceNoContent                                                                                              
INFO[0000] Attaching drive var.img, slot 2, root false.                                                                                                                         
INFO[0000] Attached drive var.img: [PUT /drives/{drive_id}][204] putGuestDriveByIdNoContent                                                                                     
INFO[0000] Attaching drive /nix/store/99ywljdlwd5p451gdi74lal27l39pa9q-rootfs.squashfs, slot 1, root true.                                                                      
2022-04-21T21:10:41.373979754 [anonymous-instance:fc_api:ERROR:src/api_server/src/parsed_request.rs:174] Received Error. Status code: 400 Bad Request. Message: Unable to create
 the block device BackingFile(Os { code: 30, kind: Other, message: "Read-only file system" })                                                                                   
ERRO[0000] Attach drive failed: /nix/store/99ywljdlwd5p451gdi74lal27l39pa9q-rootfs.squashfs: [PUT /drives/{drive_id}][400] putGuestDriveByIdBadRequest  &{FaultMessage:Unable to
 create the block device BackingFile(Os { code: 30, kind: Other, message: "Read-only file system" })} 
ERRO[0000] While attaching drive /nix/store/99ywljdlwd5p451gdi74lal27l39pa9q-rootfs.squashfs, got error [PUT /drives/{drive_id}][400] putGuestDriveByIdBadRequest  &{FaultMessag
e:Unable to create the block device BackingFile(Os { code: 30, kind: Other, message: "Read-only file system" })} 
WARN[0000] Failed handler "fcinit.AttachDrives": [PUT /drives/{drive_id}][400] putGuestDriveByIdBadRequest  &{FaultMessage:Unable to create the block device BackingFile(Os { co
de: 30, kind: Other, message: "Read-only file system" })} 
FATA[0000] Failed to start machine: [PUT /drives/{drive_id}][400] putGuestDriveByIdBadRequest  &{FaultMessage:Unable to create the block device BackingFile(Os { code: 30, kind:
 Other, message: "Read-only file system" })}
```