### PR TITLE
nixos-modules/host: enable Kernel Same-Page Merging

### DIFF
--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -198,5 +198,8 @@ in
     environment.etc."qemu/bridge.conf".text = lib.mkDefault ''
       allow all
     '';
+
+    # Enable Kernel Same-Page Merging
+    hardware.ksm.enable = true;
   };
 }


### PR DESCRIPTION
KSM seems like a sensible feature to save memory when running many MicroVMs. Yet I get zero shared pages with both QEMU and Cloud-Hypervisor.