### PR TITLE
microvm-install fixes

### DIFF
--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -95,12 +95,12 @@ in
             mkdir -p ${stateDir}/${name}
             cd ${stateDir}/${name}
 
-            ln -sf ${runner} current
+            ln -sTf ${runner} current
 
             echo '${if updateFlake != null
                     then updateFlake
                     else flake}' > flake
-            chown ${user}:${group} . current flake
+            chown -h ${user}:${group} . current flake
           '';
         serviceConfig.SyslogIdentifier = "install-microvm-${name}";
       };


### PR DESCRIPTION
When run multiple times, ln -sf ${runner} current tries to create
nested symlinks inside of the directory linked to by the previous
invokation.

Without -h, chown dereferences symlinks and tries to change the owner of
files in the nix store.
