### PR TITLE
fix modprobe path

### DIFF
--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -165,7 +165,7 @@ in
         script = ''
           cd ${stateDir}/$1
 
-          modprobe vfio-pci
+          ${pkgs.kmod}/bin/modprobe vfio-pci
 
           for path in $(cat current/share/microvm/pci-devices); do
             pushd /sys/bus/pci/devices/$path


### PR DESCRIPTION
I was trying out vfio pci passthrough, and got this error:

```
Nov 15 08:06:33 nas2 systemd[1]: Starting Setup MicroVM 'automation' devices for passthrough...
Nov 15 08:06:33 nas2 microvm-pci-devices@automation[41180]: /nix/store/hvza7mjgaqi3ybawya1mhzsv42f46mw7-unit-script-microvm-pci-devices_-start/bin/microvm-pci-devices_-start: line 5: modprobe: command not found
```

This PR solves it.