### PR TITLE
lib/runners/crosvm: Clean-up control socket

### DIFF
--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -10,6 +10,8 @@ let
   mktuntap = pkgs.callPackage ../../pkgs/mktuntap.nix {};
   interfaceFdOffset = 3;
 in {
+  preStart = "rm -f ${socket}";
+
   command =
     if user != null
     then throw "crosvm will not change user"


### PR DESCRIPTION
crosvm doesn't properly clean the control socket when it stops, ensure there is no control socket, to avoid "Address already in use" when it is trying to start again.

Signed-off-by: Mika Tammi <mika.tammi@unikie.com>