### PR TITLE
Make QEMU, CrosVM, Cloud-Hypervisor, Firecracker and kvmtool work on both x86_64 and aarch64

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  inherit (pkgs) lib;
+  inherit (pkgs) lib system;
   inherit (microvmConfig) vcpu mem balloonMem user interfaces volumes shares socket devices hugepageMem;
 
   # balloon
@@ -13,6 +13,11 @@ let
 
   # Transform attrs to parameters in form of `key1=value1,key2=value2,[...]`
   opsMapped = ops: lib.concatStringsSep "," (lib.mapAttrsToList (k: v: "${k}=${v}") ops);
+
+  kernelPath = {
+    x86_64-linux = "${kernel.dev}/vmlinux";
+    aarch64-linux = "${kernel.out}/${pkgs.stdenv.hostPlatform.linux-kernel.target}";
+  }.${system};
 
   # Attrs representing CHV mem options
   memOps = opsMapped ({
@@ -71,7 +76,7 @@ in {
         "--watchdog"
         "--console" "tty"
         "--serial" "pty"
-        "--kernel" "${kernel.dev}/vmlinux"
+        "--kernel" "${kernelPath}"
         "--cmdline" "console=hvc0 console=ttyS0 reboot=t panic=-1 ${toString microvmConfig.kernelParams}"
         "--seccomp" "true"
         "--memory" memOps

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -5,11 +5,15 @@
 }:
 
 let
-  inherit (pkgs) lib;
+  inherit (pkgs) lib system;
   inherit (microvmConfig) vcpu mem balloonMem user interfaces volumes shares socket devices;
   inherit (microvmConfig.crosvm) pivotRoot extraArgs;
   mktuntap = pkgs.callPackage ../../pkgs/mktuntap.nix {};
   interfaceFdOffset = 3;
+  kernelPath = {
+    x86_64-linux = "${kernel.dev}/vmlinux";
+    aarch64-linux = "${kernel.out}/${pkgs.stdenv.hostPlatform.linux-kernel.target}";
+  }.${system};
 in {
   preStart = ''
     rm -f ${socket}
@@ -77,7 +81,7 @@ in {
         usb = throw "USB passthrough is not supported on crosvm";
       }.${bus}) devices
       ++
-      [ "${kernel.dev}/vmlinux" ]
+      [ "${kernelPath}" ]
       ++
       extraArgs
     );

--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -26,6 +26,10 @@ in {
         "--root-drive=${bootDisk}:ro"
       ]
       ++
+      # Without this, starting of firecracker fails with an error message:
+      # Enabling simultaneous multithreading is not supported on aarch64
+      lib.optionals (system == "aarch64-linux") [ "--disable-smt" ]
+      ++
       lib.optionals (socket != null) [ "-s" socket ]
       ++
       map ({ image, ... }:

--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -5,8 +5,12 @@
 }:
 
 let
-  inherit (pkgs) lib;
+  inherit (pkgs) lib system;
   inherit (microvmConfig) vcpu mem user interfaces volumes shares socket devices;
+  kernelPath = {
+    x86_64-linux = "${kernel.dev}/vmlinux";
+    aarch64-linux = "${kernel.out}/${pkgs.stdenv.hostPlatform.linux-kernel.target}";
+  }.${system};
 in {
   command =
     if user != null
@@ -17,7 +21,7 @@ in {
         "--firecracker-binary=${pkgs.firecracker}/bin/firecracker"
         "-m" (toString mem)
         "-c" (toString vcpu)
-        "--kernel=${kernel.dev}/vmlinux"
+        "--kernel=${kernelPath}"
         "--kernel-opts=console=ttyS0 noapic reboot=k panic=1 pci=off i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd ${toString microvmConfig.kernelParams}"
         "--root-drive=${bootDisk}:ro"
       ]

--- a/lib/runners/kvmtool.nix
+++ b/lib/runners/kvmtool.nix
@@ -25,7 +25,7 @@ in {
         "-d" "${bootDisk},ro"
         "--console" "virtio"
         "--rng"
-        "-k" "${kernel}/bzImage"
+        "-k" "${kernel}/${pkgs.stdenv.hostPlatform.linux-kernel.target}"
         "-p" "console=hvc0 reboot=k panic=1 nomodules ${toString microvmConfig.kernelParams}"
       ]
       ++


### PR DESCRIPTION
Created this to open discussion. Relates to #69 

On x86_64, some hypervisors are able to load the ELF-formatted vmlinux binaries, which have debugging symbols included. However, this does not apply currently for aarch64-linux.

Signed-off-by: Mika Tammi <mika.tammi@unikie.com>
