### PR TITLE
CHV: fix vfio perm and limits + hugepages

### DIFF
--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -13,7 +13,7 @@ let
   inherit (import ../lib { nixpkgs-lib = lib; }) createVolumesScript;
 
   hypervisorConfig = import (./runners + "/${microvmConfig.hypervisor}.nix") {
-    inherit pkgs microvmConfig kernel bootDisk;
+    inherit pkgs microvmConfig kernel bootDisk lib;
   };
 
   inherit (hypervisorConfig) command canShutdown shutdownCommand;

--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -80,6 +80,21 @@ in
       extraGroups = [ "disk" ];
     };
 
+    security.pam.loginLimits = [
+      {
+        domain = "${user}";
+        item = "memlock";
+        type = "hard";
+        value = "infinity";
+      }
+      {
+        domain = "${user}";
+        item = "memlock";
+        type = "soft";
+        value = "infinity";
+      }
+    ];
+
     systemd.services = builtins.foldl' (result: name: result // {
       "install-microvm-${name}" = {
         description = "Install MicroVM '${name}'";
@@ -250,6 +265,7 @@ in
           Group = group;
           SyslogIdentifier = "microvm@%i";
           LimitNOFILE = 1048576;
+          LimitMEMLOCK = "infinity";
         };
       };
     } (builtins.attrNames config.microvm.vms);

--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -1,6 +1,5 @@
 { pkgs, config, lib, ... }:
 let
-  inherit (pkgs) system;
   stateDir = config.microvm.stateDir;
   microvmCommand = import ../pkgs/microvm-command.nix {
     inherit pkgs;
@@ -69,7 +68,7 @@ in
       chmod g+w ${stateDir}
     '';
 
-    environment.systemPackages = with pkgs; [
+    environment.systemPackages = [
       microvmCommand
     ];
 

--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -174,6 +174,17 @@ in
             fi
             echo vfio-pci > driver_override
             echo $path > /sys/bus/pci/drivers_probe
+
+            # In order to access the vfio dev the permissions must be set
+            # for the user/group running the VMM later.
+            #
+            # Insprired by https://www.kernel.org/doc/html/next/driver-api/vfio.html#vfio-usage-example
+            #
+            # assert we could get the IOMMU group number (=: name of VFIO dev)
+            [[ -e iommu_group ]] || exit 1
+            VFIO_DEV=$(basename $(readlink iommu_group))
+            echo "Making VFIO device $VFIO_DEV accessible for user"
+            chown ${user}:${group} /dev/vfio/$VFIO_DEV
             popd
           done
         '';

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -57,6 +57,15 @@ in
       type = types.int;
     };
 
+    hugepageMem = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to use hugepages as memory backend.
+        (Currently only respected if using cloud-hypervisor)
+      '';
+    };
+
     balloonMem = mkOption {
       description = ''
         Amount of balloon memory in megabytes


### PR DESCRIPTION
Changes regarding cloud-hypervisor (CHV):
  - change the permission of the vfio dev  
  - set memlock in limits
  - add hugepage option 

@astro if you wish i could split this PR into separate ones. 