### PR TITLE
remove "no control socket" restriction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ imperatively with the provided `microvm` command.
 | [qemu](https://www.qemu.org/)                                           | C        |                                       |
 | [cloud-hypervisor](https://www.cloudhypervisor.org/)                    | Rust     | no 9p shares                          |
 | [firecracker](https://firecracker-microvm.github.io/)                   | Rust     | no 9p/virtiofs shares                 |
-| [crosvm](https://chromium.googlesource.com/chromiumos/platform/crosvm/) | Rust     | no control socket                     |
+| [crosvm](https://chromium.googlesource.com/chromiumos/platform/crosvm/) | Rust     |                                       |
 | [kvmtool](https://github.com/kvmtool/kvmtool)                           | C        | no virtiofs shares, no control socket |
 
 


### PR DESCRIPTION
The README.md states crosvm has no control socket, yet it appears to have one:
https://crosvm.dev/book/running_crosvm/advanced_usage.html?highlight=control%20sock#control-socket

and appears to be implemented here:
https://github.com/astro/microvm.nix/blob/main/lib/runners/crosvm.nix#L52