### PR TITLE
kvmtool: Change kernel path generation method

### DIFF
--- a/lib/runners/kvmtool.nix
+++ b/lib/runners/kvmtool.nix
@@ -25,7 +25,7 @@ in {
         "-d" "${bootDisk},ro"
         "--console" "virtio"
         "--rng"
-        "-k" "${kernel}/bzImage"
+        "-k" "${kernel}/${pkgs.stdenv.hostPlatform.linux-kernel.target}"
         "-p" "console=hvc0 reboot=k panic=1 nomodules ${toString microvmConfig.kernelParams}"
       ]
       ++


### PR DESCRIPTION
Change kvmtool to use the more portable
${pkgs.stdenv.hostPlatform.linux-kernel.target} as a kernel image filename, instead of the hardcoded bzImage.