### PR TITLE
fix microvm -r command

### DIFF
--- a/pkgs/microvm-command.nix
+++ b/pkgs/microvm-command.nix
@@ -46,6 +46,7 @@ writeScriptBin "microvm" ''
 
       r)
         ACTION=run
+        NAME=$OPTARG
         ;;
 
       l)


### PR DESCRIPTION
`microvm -r vmname` fails due to missing $NAME variable.