### PR TITLE
qemu: Require PCI for PCI passthrough on x86_64

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -26,7 +26,9 @@ let
   volumes = withDriveLetters 1 microvmConfig.volumes;
 
   arch = builtins.head (builtins.split "-" system);
-  requirePci = shares != [];
+  # PCI required by vfio-pci for PCI passthrough
+  pciInDevices = lib.any ({ bus, ... }: bus == "pci") devices;
+  requirePci = shares != [] || pciInDevices;
   machine = {
     x86_64-linux =
       if requirePci
@@ -74,7 +76,6 @@ let
 in {
   hypervisor = "qemu";
 
-  # TODO : Needs work
   command = lib.escapeShellArgs (
     [
       "${qemu}/bin/qemu-system-${arch}"


### PR DESCRIPTION
vfio-pci requires PCI bus for qemu

Otherwise you get errors like:
`qemu-system-x86_64: -device vfio-pci,host=0000:00:14.3,multifunction=on: No 'PCI' bus found for device 'vfio-pci'`