### PR TITLE
Create macvtap interface link

### DIFF
--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -1,8 +1,8 @@
 { pkgs
 , microvmConfig
 , kernel ? pkgs.callPackage ../pkgs/microvm-kernel.nix {
-  inherit (pkgs.linuxPackages_latest) kernel;
-}
+    inherit (pkgs.linuxPackages_latest) kernel;
+  }
 , bootDisk
 , toplevel
 }:
@@ -56,7 +56,8 @@ let
   '';
 in
 
-pkgs.runCommand "microvm-${microvmConfig.hypervisor}-${microvmConfig.hostName}" {
+pkgs.runCommand "microvm-${microvmConfig.hypervisor}-${microvmConfig.hostName}"
+{
   # for `nix run`
   meta.mainProgram = "microvm-run";
   passthru = {
@@ -83,6 +84,12 @@ pkgs.runCommand "microvm-${microvmConfig.hypervisor}-${microvmConfig.hostName}" 
     lib.optionalString (interface.type == "tap" && interface ? id) ''
       echo "${interface.id}" >> $out/share/microvm/tap-interfaces
     '') microvmConfig.interfaces}
+
+  ${lib.concatMapStringsSep " " (interface:
+    lib.optionalString (interface.type == "macvtap" && interface ? id) ''
+      echo "${interface.id} ${interface.mac}" >> $out/share/microvm/macvtap-interfaces
+    '') microvmConfig.interfaces}
+
 
   ${lib.concatMapStrings ({ tag, socket, source, proto, ... }:
       lib.optionalString (proto == "virtiofs") ''

--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -86,8 +86,8 @@ pkgs.runCommand "microvm-${microvmConfig.hypervisor}-${microvmConfig.hostName}"
     '') microvmConfig.interfaces}
 
   ${lib.concatMapStringsSep " " (interface:
-    lib.optionalString (interface.type == "macvtap" && interface ? id) ''
-      echo "${interface.id} ${interface.mac}" >> $out/share/microvm/macvtap-interfaces
+    lib.optionalString (interface.type == "macvtap" && interface ? id && interface ? link) ''
+      echo "${interface.id} ${interface.link} ${interface.mac}" >> $out/share/microvm/macvtap-interfaces
     '') microvmConfig.interfaces}
 
 

--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -86,8 +86,13 @@ pkgs.runCommand "microvm-${microvmConfig.hypervisor}-${microvmConfig.hostName}"
     '') microvmConfig.interfaces}
 
   ${lib.concatMapStringsSep " " (interface:
-    lib.optionalString (interface.type == "macvtap" && interface ? id && interface ? link) ''
-      echo "${interface.id} ${interface.link} ${interface.mac}" >> $out/share/microvm/macvtap-interfaces
+    lib.optionalString (interface.type == "macvtap" && interface ? id  && interface ? macvtap && interface.macvtap ? link) ''
+      echo "${builtins.concatStringsSep " " [
+        interface.id
+        interface.mac
+        interface.macvtap.link
+        (builtins.toString interface.macvtap.mode)
+      ]}" >> $out/share/microvm/macvtap-interfaces
     '') microvmConfig.interfaces}
 
 

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -141,7 +141,7 @@ in {
       forwardPorts != [] &&
       ! builtins.any ({ type, ... }: type == "user") interfaces
     ) "${hostName}: forwardPortsOptions only running with user network" (
-      builtins.concatMap ({ type, id, mac, bridge }: [
+      builtins.concatMap ({ type, id, mac, bridge, ... }: [
         "-netdev" (
           lib.concatStringsSep "," (
             [

--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -204,12 +204,13 @@ in
           cat current/share/microvm/macvtap-interfaces | while read -r line;do
             opts=( $line )
             id="''${opts[0]}"
-            link="''${opts[1]}"
-            mac="''${opts[2]}"
+            mac="''${opts[1]}"
+            link="''${opts[2]}"
+            mode="''${opts[3]}"
             if [ -e /sys/class/net/$id ]; then
               ${pkgs.iproute2}/bin/ip link del name $id
             fi
-            ${pkgs.iproute2}/bin/ip link add link $link name $id address $mac type macvtap
+            ${pkgs.iproute2}/bin/ip link add link $link name $id address $mac type macvtap"''${mode:+" mode $mode"}"
             ${pkgs.iproute2}/bin/ip link set $id up
             ${pkgs.coreutils-full}/bin/chown ${user}:${group} /dev/tap$(< /sys/class/net/$id/ifindex) 
           done

--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -190,7 +190,7 @@ in
                 cat current/share/microvm/macvtap-interfaces | while read -r line;do
                   opts=( $line )
                   id="''${opts[0]}"
-                  ${pkgs.iproute2}/bin/ip del name $id
+                  ${pkgs.iproute2}/bin/ip link del name $id
                 done
               '';
             in "${stopScript} %i";
@@ -206,13 +206,12 @@ in
             id="''${opts[0]}"
             link="''${opts[1]}"
             mac="''${opts[2]}"
-            if [ -e /sys/class/net/$name ]; then
-              ${pkgs.iproute2}/bin/ip link del name $name
+            if [ -e /sys/class/net/$id ]; then
+              ${pkgs.iproute2}/bin/ip link del name $id
             fi
             ${pkgs.iproute2}/bin/ip link add link $link name $id address $mac type macvtap
-            ${pkgs.iproute2}/bin/ip set $id up
-            ${pkgs.coreutils-full}/bin/chown ${user}:${group}
-            ((i=i+1))
+            ${pkgs.iproute2}/bin/ip link set $id up
+            ${pkgs.coreutils-full}/bin/chown ${user}:${group} /dev/tap$(< /sys/class/net/$id/ifindex) 
           done
         '';
       };

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -194,6 +194,12 @@ in
               Interface name on the host
             '';
           };
+          link = mkOption {
+            type = str;
+            description = ''
+              Attach network interface to host interface for type = "macvlan"
+            '';
+          };
           bridge = mkOption {
             type = nullOr str;
             default = null;

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -194,10 +194,17 @@ in
               Interface name on the host
             '';
           };
-          link = mkOption {
+          macvtap.link = mkOption {
             type = str;
             description = ''
               Attach network interface to host interface for type = "macvlan"
+            '';
+          };
+          macvtap.mode = mkOption {
+            type = nullOr (enum ["private" "vepa" "bridge" "passthru" "source"]);
+            default = null;
+            description = ''
+              The MACVLAN mode to use
             '';
           };
           bridge = mkOption {


### PR DESCRIPTION
Auto create macvtap interfaces with a service similar to tap interfaces. 

- Adds a `link` option to interfaces specifying which interface the auto-created macvtap should link to.
- Adds service that will create macvtap interfaces on the host

Example configuration:
```
microvm.interfaces = [{
   type="macvtap";
   id="macvtap1";  # name of the newly created interface on the host
   link="eno2";  # name of an existing interfaces that the macvtap operates on
   mac="00:00:00:00;00"; # the mac address of the macvtap interface
}];
```

Related to #80 
