### PR TITLE
Implement fully declarative approach via direct `config` as an alternative to specifying `flake`

### DIFF
--- a/doc/src/declarative.md
+++ b/doc/src/declarative.md
@@ -1,13 +1,65 @@
 # Declarative MicroVMs
 
 Provided your NixOS host [includes the host nixosModule](./host.md),
-options are declared to build a MicroVM with the host so that it gets
-deployed and start on boot.
+options are declared to build a MicroVM together with the host.
+You can choose whether your MicroVMs should be managed in a fully-declarative
+way, or whether your only want the initial deployment be declarative (with subsequent
+imperative updates using the [microvm command](./microvm-command.md)).
+
+microvm.nix distinguishes between fully-declarative configurations
+and declarative deployment by allowing you to specify either
+a full `config` or just a `flake` respectively.
+
+## Fully declarative
+
+You can create fully declarative VMs by directly defining their
+nixos system configuration in-place. This is very similar to how
+nixos-containers work if you are familiar with those.
+
+```nix
+# microvm refers to microvm.nixosModules
+{ microvm, ... }: {
+  imports = [ microvm.host ];
+  microvm.vms = {
+    my-microvm = {
+      # The package set to use for the microvm. This also determines the microvm's architecture.
+      # Defaults to the host system's package set if not given.
+      pkgs = import nixpkgs { system = "x86_64-linux"; };
+
+      # (Optional) A set of special arguments to be passed to the MicroVM's NixOS modules.
+      #specialArgs = {};
+
+      # The configuration for the MicroVM.
+      # Multiple definitions will be merged as expected.
+      config = {
+        imports = [ microvm.microvm ];
+
+        # It is highly recommended to share the host's nix-store
+        # with the VMs to prevent building huge images.
+        microvm.shares = [{
+          source = "/nix/store";
+          mountPoint = "/nix/.ro-store";
+          tag = "ro-store";
+          proto = "virtiofs";
+        }];
+
+        # This is necessary to import the host's nix-store database
+        microvm.writableStoreOverlay = true;
+
+        # Any other configuration for your MicroVM
+        #...
+      };
+    };
+  };
+}
+```
+
+## Declarative deployment
 
 Why *deployed*? The per-MicroVM subdirectory under `/var/lib/microvms`
-gets only created if it did not exist before. This behavior is
+is only created, if it did not exist before. This behavior is
 intended to ensure existence of MicroVMs that are critical to
-operation. To update later use the [imperative microvm
+operation. To update them later you will have to use the [imperative microvm
 command](./microvm-command.md).
 
 ```nix

--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -50,6 +50,14 @@ in
       '';
     };
 
+    declarativeUpdates = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Deploys updates to existing microvms automatically when the host is rebuilt.
+      '';
+    };
+
     autostart = mkOption {
       type = with types; listOf str;
       default = [];
@@ -60,11 +68,11 @@ in
       '';
     };
 
-    autorestart = mkOption {
+    restartOnChange = mkOption {
       type = types.bool;
       default = false;
       description = ''
-        Restart MicroVM services on `nixos-rebuild switch` of the host?
+        Restart MicroVM services if the systemd services are changed.
       '';
     };
   };
@@ -114,7 +122,7 @@ in
         partOf = [ "microvm@${name}.service" ];
         wantedBy = [ "microvms.target" ];
         # only run if /var/lib/microvms/$name does not exist yet
-        unitConfig.ConditionPathExists = "!${stateDir}/${name}";
+        unitConfig.ConditionPathExists = lib.mkIf (!config.microvm.declarativeUpdates) "!${stateDir}/${name}";
         serviceConfig.Type = "oneshot";
         script =
           let


### PR DESCRIPTION
This PR adds an alternative option `vms.<name>.config` that can be used instead of specifying `vms.<name>.flake`. This way of doing configuration doesn't impose any restrictions on the user's flake, but can only be used declaratively. This is similar to how e.g. nixos-container is doing this.

- This addresses #92 
- and also adds `declarativeUpdates` for #94 that restarts VMs when the toplevel is changed and the host is `nixos-rebuild --switch`-ed

This PR also renames an option which might or might not be desirable. I'm not overly familiar with the codebase yet, so I "hacked" together something to make the microvm list command work again, since it depended on the `flake` file to determine the vm's toplevel. This should probably be revised, feedback is always welcome.

Example usage:

```nix
{ microvm, pkgs, ... }: {
  microvm.declarativeUpdates = true;
  microvm.restartIfChanged = true;
  microvm.vms.test.config = {
    imports = [microvm.nixosModules.microvm];
    # typical config ...
  };
}
```

This also allows merging multiple definitions, so specifying `config` again in another module will just work:

```nix
{
  microvm.vms.test.config = {
    services.nginx.enable = true;
  };
}
```

You can also specify another `pkgs` set and `specialArgs`, in case the guest should use a different system, or needs certain special arguments:


```nix
{ microvm, pkgs, ... }: {
  microvm.vms.test = {
    inherit pkgs; # optional (default to host's pkgs), used to selects the guest system and nixpkgs package set.
    specialArgs = {}; # optional, passed to nixosSystem
    config = {
      imports = [microvm.nixosModules.microvm];
      # typical config ...
    };
  };
}
```

Remarks:

All outstanding issues have been addressed. See comments below.

- ~~currently an assertions ensures `delcarativeUpdates -> restartIfChanged`. This could maybe be merged into one option, or left out by implying declarativeUpdates when using `vms.<name>.config`.~~
- ~~I'm not familiar enough with all the systemd services that are created, so I'm not 100% confident that `restartIfChanged` is always doing what it should be doing~~
- ~~declarative vm's are not yet restarted when their toplevel is changed. Waiting on #94 to see how we will solve that.~~