### PR TITLE
fix: enable ALLMULTI flag on macvtap interfaces and disable IPv6LL addresses host-side

### DIFF
--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -211,6 +211,8 @@ in
               ${pkgs.iproute2}/bin/ip link del name $id
             fi
             ${pkgs.iproute2}/bin/ip link add link $link name $id address $mac type macvtap ''${mode[@]}
+            ${pkgs.iproute2}/bin/ip link set $id allmulticast on
+            echo 1 > /proc/sys/net/ipv6/conf/$id/disable_ipv6
             ${pkgs.iproute2}/bin/ip link set $id up
             ${pkgs.coreutils-full}/bin/chown ${user}:${group} /dev/tap$(< /sys/class/net/$id/ifindex)
           done


### PR DESCRIPTION
IPv6 neighbour solicitation, mDNS, and anything depending on multicast traffic requires the ALLMULTI flag to be set on macvtap interfaces. This allows the guest interface to influence the the multicast receive mask of the physical link. Without this, the multicast traffic intended for the guest would be discarded, breaking a lot of stuff.

libvirt makes this configurable with a setting called `trustGuestRxFilters`, since technically it grants the guest additional privileges that might not always be required. But realistically it is required in most scenarios, since multicast traffic is an integral part of networking. So this PR changes the module to add this flag by default.

This patch also sets the `disable_ipv6` flag on the host-side link to avoid generating any ipv6 addresses. This *does not* actually disable ipv6 functionality on the interface, just prevents the *host* from acquiring any addresses automatically. The guest is still able to assign IPv6 addresses, this is just about the (unused) macvtap interface on the host that is passed to the guest. Disabling this address is necessary to prevent IPv6 packets destined for a guest from being delivered to the host system aswell.