### PR TITLE
fix: allow meta access to the generated declarative nixos systems

### DIFF
--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -41,10 +41,10 @@ in
                     extraConfig
                     ./microvm
                   ] ++ (map (x: x.value) defs);
-                prefix = [ "microvm" name ];
+                prefix = [ "microvm" "vms" name "config" ];
                 inherit (config) specialArgs pkgs;
                 inherit (config.pkgs) system;
-              }).config;
+              });
             });
           };
 
@@ -175,7 +175,7 @@ in
         isFlake = flake != null;
         guestConfig = if isFlake
                       then flake.nixosConfigurations.${name}.config
-                      else microvmConfig.config;
+                      else microvmConfig.config.config;
         runner = guestConfig.microvm.declaredRunner;
       in
     {


### PR DESCRIPTION
Currently, accessing `config.microvm.vms.<name>.config` directly exposes the *content* of the configuration. This is undesirable because it hides (and prevent access to) any meta information returned by `eval-config.nix`. This is for example stuff like `options` which exposes the definition values and locations of options which is useful for debugging and necessary for some advanced stuff.

This change exposes the full generated attrset in the `config` attribute. This has no effect for users, the option is still used in the same way. (The old result can also still be accessed by adding `.config`).