### PR TITLE
make `nixos-modules/microvm/mounts.nix` opt-out

### DIFF
--- a/nixos-modules/microvm/mounts.nix
+++ b/nixos-modules/microvm/mounts.nix
@@ -19,7 +19,7 @@ let
     else hostStore.mountPoint;
 
 in
-{
+lib.mkIf config.microvm.guest.enable {
   fileSystems = lib.mkMerge [ (
     # built-in read-only store without overlay
     lib.optionalAttrs (


### PR DESCRIPTION
I started getting below error, looks like it's because `mounts.nix` was not created to be opted out:

```
       error: The option `fileSystems."/nix/store".fsType' has conflicting definition values:
       - In `/nix/store/5my0m9fdfsazzc5m6z0wc8b2k66xwnm3-source/modules': "zfs"
       - In `/nix/store/3xmpkg4m13l8h2a278gqbwc8r0fz5f6w-source/nixos-modules/microvm/mounts.nix': "erofs"
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```