### PR TITLE
Disable seccomp filter to fix crash on nixos-23.05

### DIFF
--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -370,6 +370,7 @@ in
             mkdir -p $SOURCE
 
             virtiofsd \
+              --seccomp=none \
               --socket-path=$SOCKET \
               --socket-group=${config.users.users.microvm.group} \
               --shared-dir $SOURCE \


### PR DESCRIPTION
see https://gitlab.com/virtio-fs/virtiofsd/-/issues/104