### PR TITLE
Remove un-needed i8042 device from qemu command line

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -94,7 +94,6 @@ in {
 
       "-chardev" "stdio,id=stdio,signal=off"
       "-serial" "chardev:stdio"
-      "-device" "i8042"
       "-device" "virtio-rng-${devType}"
       "-kernel" "${kernelPath}"
       "-initrd" bootDisk.passthru.initrd


### PR DESCRIPTION
The i8042 device is added to qemu command line for all platforms, whereas it's needed only for x86. It's already added for the platform in line #106.