### PR TITLE
boot-disk: Evaluate libguestfs-appliance only when needed

### DIFF
--- a/nixos-modules/microvm/boot-disk.nix
+++ b/nixos-modules/microvm/boot-disk.nix
@@ -24,7 +24,9 @@ in {
         parted
         libguestfs
       ];
-      LIBGUESTFS_PATH = pkgs.libguestfs-appliance;
+      # HACK: Do not evaluate libguestfs-appliance for others than
+      #       cloud-hypervisor and on x86_64.
+      LIBGUESTFS_PATH = lib.optionalString (config.microvm.hypervisor == "cloud-hypervisor" && pkgs.hostPlatform.isx86_64) pkgs.libguestfs-appliance;
       passthru = {
         kernel = kernelPath;
         initrd = initrdPath;


### PR DESCRIPTION
Only evaluate libguestfs-appliance as part of the boot-disk when needed. This is to enable builds on aarch64-linux platforms against nixos-unstable.