### PR TITLE
fix: explicitly empty the path of asDropin overrides to prevent clobbering it

### DIFF
--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -217,6 +217,7 @@ in
       "microvm@${name}" = {
         # restartIfChanged is opt-out, so we have to include the definition unconditionally
         serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
+        path = lib.mkForce [];
         # If the given declarative microvm wants to be restarted on change,
         # We have to make sure this service group is restarted. To make sure
         # that this service is also changed when the microvm configuration changes,
@@ -226,14 +227,17 @@ in
       };
       "microvm-tap-interfaces@${name}" = {
         serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
+        path = lib.mkForce [];
         overrideStrategy = "asDropin";
       };
       "microvm-pci-devices@${name}" = {
         serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
+        path = lib.mkForce [];
         overrideStrategy = "asDropin";
       };
       "microvm-virtiofsd@${name}" = {
         serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
+        path = lib.mkForce [];
         overrideStrategy = "asDropin";
       };
     })) {


### PR DESCRIPTION
This is a necessary workaround for https://github.com/NixOS/nixpkgs/issues/219013