### PR TITLE
Fix issue related to romfile= argument

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -170,7 +170,9 @@ in {
             ]
           )
         )
-        "-device" "virtio-net-${devType},netdev=${id},mac=${mac},romfile="
+        "-device" ("virtio-net-${devType},netdev=${id},mac=${mac}" +
+	  # romfile= does not work with x86_64-linux and -M microvm setting
+	  lib.optionalString (requirePci || system != "x86_64-linux") ",romfile=")
       ]) interfaces
     )
     ++


### PR DESCRIPTION
Fixes the `Property 'virtio-net-device.romfile' not found` error, if running `-M microvm` -kind of configuration on x86_64-linux.