### PR TITLE
nixos-modules/microvm/options: use nonEmptyStr instead of path for shares.*.source

### DIFF
--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -257,7 +257,7 @@ in
             description = "Socket for communication with virtiofs daemon";
           };
           source = mkOption {
-            type = path;
+            type = nonEmptyStr;
             description = "Path to shared directory tree";
           };
           mountPoint = mkOption {


### PR DESCRIPTION
closes #138 