### PR TITLE
Update cloud hypervisor

### DIFF
--- a/pkgs/spectrum-os/cloud-hypervisor/0001-build-use-local-vhost.patch
+++ b/pkgs/spectrum-os/cloud-hypervisor/0001-build-use-local-vhost.patch
@@ -1,4 +1,4 @@
-From 9ac46605a87746d2d3e5a46a75cde33a7f01d31c Mon Sep 17 00:00:00 2001
+From 553849a8c6fd835909f8d0fac52578cae120c4f1 Mon Sep 17 00:00:00 2001
 From: Alyssa Ross <alyssa.ross@unikie.com>
 Date: Wed, 28 Sep 2022 12:18:19 +0000
 Subject: [PATCH 1/2] build: use local vhost
@@ -6,35 +6,45 @@ Subject: [PATCH 1/2] build: use local vhost
 Signed-off-by: Alyssa Ross <alyssa.ross@unikie.com>
 Signed-off-by: Alyssa Ross <hi@alyssa.is>
 ---
- Cargo.lock | 2 --
- Cargo.toml | 1 +
- 2 files changed, 1 insertion(+), 2 deletions(-)
+ Cargo.lock | 3 ---
+ Cargo.toml | 3 ++-
+ 2 files changed, 2 insertions(+), 4 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index f4e667f7..d4e58b21 100644
+index ee130b37..687a9d78 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1413,8 +1413,6 @@ dependencies = [
+@@ -2133,7 +2133,6 @@ dependencies = [
  [[package]]
  name = "vhost"
- version = "0.6.0"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c9b791c5b0717a0558888a4cf7240cea836f39a99cb342e12ce633dcaa078072"
+ version = "0.7.0"
+-source = "git+https://github.com/rust-vmm/vhost?branch=main#bdc6f2ab2b3dbd3b9574100ac641a2f8e9667400"
  dependencies = [
-  "bitflags",
+  "bitflags 1.3.2",
   "libc",
+@@ -2144,8 +2143,6 @@ dependencies = [
+ [[package]]
+ name = "vhost-user-backend"
+ version = "0.9.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a5d3b7affe04f61d19b03c5db823287855789b687218fec139699a0c7f7f2790"
+ dependencies = [
+  "libc",
+  "log",
 diff --git a/Cargo.toml b/Cargo.toml
-index 230bd499..dcd5bb24 100644
+index d75e2536..976b6662 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -53,6 +53,7 @@ vm-memory = "0.10.0"
- [patch.crates-io]
+@@ -55,7 +55,8 @@ zbus = { version = "3.11.1", optional = true }
  kvm-bindings = { git = "https://github.com/cloud-hypervisor/kvm-bindings", branch = "ch-v0.6.0-tdx" }
+ kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "main" }
  versionize_derive = { git = "https://github.com/cloud-hypervisor/versionize_derive", branch = "ch" }
+-vhost = { git = "https://github.com/rust-vmm/vhost", branch = "main" }
 +vhost = { path = "../vhost/crates/vhost" }
++vhost-user-backend = { path = "../vhost/crates/vhost-user-backend" }
  
  [dev-dependencies]
- dirs = "4.0.0"
+ dirs = "5.0.0"
 -- 
-2.37.1
+2.42.0
 

--- a/pkgs/spectrum-os/cloud-hypervisor/0002-virtio-devices-add-a-GPU-device.patch
+++ b/pkgs/spectrum-os/cloud-hypervisor/0002-virtio-devices-add-a-GPU-device.patch
@@ -1,4 +1,4 @@
-From 5d4b824e72a329b587d11fd1b562ed9dc3633c7f Mon Sep 17 00:00:00 2001
+From 0fb5900d6d4086fc4f9a7fe43a590cb22feec9f5 Mon Sep 17 00:00:00 2001
 From: Alyssa Ross <alyssa.ross@unikie.com>
 Date: Wed, 7 Sep 2022 14:16:29 +0000
 Subject: [PATCH 2/2] virtio-devices: add a GPU device
@@ -20,48 +20,45 @@ are read-only, and crosvm does not properly handle this, causing
 cloud-hypervisor to crash.
 
 Signed-off-by: Alyssa Ross <alyssa.ross@unikie.com>
-Co-authored-by: Puck Meerburg <puck@puckipedia.com>
-Signed-off-by: Puck Meerburg <puck@puckipedia.com>
 Co-authored-by: Alyssa Ross <hi@alyssa.is>
 Signed-off-by: Alyssa Ross <hi@alyssa.is>
 ---
- Cargo.lock                                    |   1 +
- src/main.rs                                   |  12 +
- virtio-devices/src/device.rs                  |   8 +-
- virtio-devices/src/lib.rs                     |   2 +
- virtio-devices/src/seccomp_filters.rs         |  10 +
- virtio-devices/src/transport/pci_device.rs    |   4 +-
- virtio-devices/src/vhost_user/gpu.rs          | 373 ++++++++++++++++++
- virtio-devices/src/vhost_user/mod.rs          |   2 +
- .../src/vhost_user/vu_common_ctrl.rs          |  14 +-
- vmm/Cargo.toml                                |   1 +
- vmm/src/api/mod.rs                            |   7 +
- vmm/src/config.rs                             | 105 ++++-
- vmm/src/device_manager.rs                     | 139 ++++++-
- vmm/src/lib.rs                                |  83 ++++
- vmm/src/vm.rs                                 |  33 +-
- vmm/src/vm_config.rs                          |  25 ++
- 16 files changed, 802 insertions(+), 17 deletions(-)
+ Cargo.lock                                 |   1 +
+ src/main.rs                                |  12 +
+ virtio-devices/src/device.rs               |   8 +-
+ virtio-devices/src/lib.rs                  |   4 +-
+ virtio-devices/src/seccomp_filters.rs      |  16 +
+ virtio-devices/src/transport/pci_device.rs |   4 +-
+ virtio-devices/src/vhost_user/gpu.rs       | 406 +++++++++++++++++++++
+ virtio-devices/src/vhost_user/mod.rs       |   2 +
+ vmm/Cargo.toml                             |   1 +
+ vmm/src/api/mod.rs                         |  10 +-
+ vmm/src/config.rs                          | 111 ++++++
+ vmm/src/device_manager.rs                  | 140 ++++++-
+ vmm/src/lib.rs                             |  88 ++++-
+ vmm/src/vm.rs                              |  28 +-
+ vmm/src/vm_config.rs                       |  27 ++
+ 15 files changed, 841 insertions(+), 17 deletions(-)
  create mode 100644 virtio-devices/src/vhost_user/gpu.rs
 
 diff --git a/Cargo.lock b/Cargo.lock
-index d4e58b21..bc51e03b 100644
+index 687a9d78..fe172da4 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1630,6 +1630,7 @@ dependencies = [
+@@ -2340,6 +2340,7 @@ dependencies = [
+  "versionize_derive",
   "vfio-ioctls",
   "vfio_user",
-  "vhdx",
-+ "virtio-bindings 0.2.0",
++ "virtio-bindings",
   "virtio-devices",
   "virtio-queue",
   "vm-allocator",
 diff --git a/src/main.rs b/src/main.rs
-index eca2d2fa..8393f699 100644
+index 780b282b..56108ccf 100644
 --- a/src/main.rs
 +++ b/src/main.rs
-@@ -188,6 +188,10 @@ pub struct TopLevel {
-     /// tag=<tag_name>,socket=<socket_path>,num_queues=<number_of_queues>,queue_size=<size_of_each_queue>,id=<device_id>,pci_segment=<segment_id>
+@@ -199,6 +199,10 @@ pub struct TopLevel {
+     /// tag=<tag_name>, socket=<socket_path>, num_queues=<number_of_queues>, queue_size=<size_of_each_queue>, id=<device_id>, pci_segment=<segment_id>
      fs: Vec<String>,
  
 +    #[argh(option, long = "gpu")]
@@ -69,9 +66,9 @@ index eca2d2fa..8393f699 100644
 +    gpu: Vec<String>,
 +
      #[argh(option, long = "pmem")]
-     /// file=<backing_file_path>,size=<persistent_memory_size>,iommu=on|off,discard_writes=on|off,id=<device_id>,pci_segment=<segment_id>
+     /// file=<backing_file_path>, size=<persistent_memory_size>, iommu=on|off, discard_writes=on|off, id=<device_id>, pci_segment=<segment_id>
      pmem: Vec<String>,
-@@ -303,6 +307,12 @@ impl TopLevel {
+@@ -333,6 +337,12 @@ impl TopLevel {
              None
          };
  
@@ -84,7 +81,7 @@ index eca2d2fa..8393f699 100644
          let pmem = if !self.pmem.is_empty() {
              Some(self.pmem.iter().map(|x| x.as_str()).collect())
          } else {
-@@ -356,6 +366,7 @@ impl TopLevel {
+@@ -389,6 +399,7 @@ impl TopLevel {
              rng,
              balloon,
              fs,
@@ -92,7 +89,7 @@ index eca2d2fa..8393f699 100644
              pmem,
              serial,
              console,
-@@ -707,6 +718,7 @@ mod unit_tests {
+@@ -776,6 +787,7 @@ mod unit_tests {
              },
              balloon: None,
              fs: None,
@@ -137,20 +134,29 @@ index b70092f8..e091ddd6 100644
  
  /// Trait for virtio devices to be driven by a virtio transport.
 diff --git a/virtio-devices/src/lib.rs b/virtio-devices/src/lib.rs
-index f7037692..98c39658 100644
+index 680cbe29..55428cd8 100644
 --- a/virtio-devices/src/lib.rs
 +++ b/virtio-devices/src/lib.rs
-@@ -86,6 +86,8 @@ pub enum ActivateError {
-     ThreadSpawn(std::io::Error),
-     #[error("Failed to setup vhost-user-fs daemon: {0}")]
+@@ -44,7 +44,7 @@ pub use self::block::{Block, BlockState};
+ pub use self::console::{Console, ConsoleResizer, Endpoint};
+ pub use self::device::{
+     DmaRemapping, UserspaceMapping, VirtioCommon, VirtioDevice, VirtioInterrupt,
+-    VirtioInterruptType, VirtioSharedMemoryList,
++    VirtioInterruptType, VirtioSharedMemory, VirtioSharedMemoryList,
+ };
+ pub use self::epoll_helper::{
+     EpollHelper, EpollHelperError, EpollHelperHandler, EPOLL_HELPER_EVENT_LAST,
+@@ -93,6 +93,8 @@ pub enum ActivateError {
      VhostUserFsSetup(vhost_user::Error),
+     #[error("Failed to setup vhost-user daemon: {0}")]
+     VhostUserSetup(vhost_user::Error),
 +    #[error("Failed to setup vhost-user-gpu daemon: {0}")]
 +    VhostUserGpuSetup(vhost_user::Error),
-     #[error("Failed to setup vhost-user-blk daemon: {0}")]
-     VhostUserBlkSetup(vhost_user::Error),
      #[error("Failed to create seccomp filter: {0}")]
+     CreateSeccompFilter(seccompiler::Error),
+     #[error("Failed to create rate limiter: {0}")]
 diff --git a/virtio-devices/src/seccomp_filters.rs b/virtio-devices/src/seccomp_filters.rs
-index 1e689591..823e6cec 100644
+index 43d723b8..8620419f 100644
 --- a/virtio-devices/src/seccomp_filters.rs
 +++ b/virtio-devices/src/seccomp_filters.rs
 @@ -22,6 +22,7 @@ pub enum Thread {
@@ -161,22 +167,28 @@ index 1e689591..823e6cec 100644
      VirtioVhostNet,
      VirtioVhostNetCtl,
      VirtioVsock,
-@@ -162,6 +163,14 @@ fn virtio_vhost_fs_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
+@@ -163,6 +164,20 @@ fn virtio_vhost_fs_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
      ]
  }
  
 +fn virtio_vhost_gpu_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
 +    vec![
++        (libc::SYS_clock_nanosleep, vec![]),
++        (libc::SYS_connect, vec![]),
 +        (libc::SYS_getcwd, vec![]),
++        (libc::SYS_nanosleep, vec![]),
++        (libc::SYS_recvmsg, vec![]),
 +        (libc::SYS_recvmsg, vec![]),
 +        (libc::SYS_sendmsg, vec![]),
++        (libc::SYS_sendmsg, vec![]),
++        (libc::SYS_socket, vec![]),
 +    ]
 +}
 +
  fn virtio_vhost_net_ctl_thread_rules() -> Vec<(i64, Vec<SeccompRule>)> {
      vec![]
  }
-@@ -223,6 +232,7 @@ fn get_seccomp_rules(thread_type: Thread) -> Vec<(i64, Vec<SeccompRule>)> {
+@@ -234,6 +249,7 @@ fn get_seccomp_rules(thread_type: Thread) -> Vec<(i64, Vec<SeccompRule>)> {
          Thread::VirtioRng => virtio_rng_thread_rules(),
          Thread::VirtioVhostBlock => virtio_vhost_block_thread_rules(),
          Thread::VirtioVhostFs => virtio_vhost_fs_thread_rules(),
@@ -185,17 +197,17 @@ index 1e689591..823e6cec 100644
          Thread::VirtioVhostNetCtl => virtio_vhost_net_ctl_thread_rules(),
          Thread::VirtioVsock => virtio_vsock_thread_rules(),
 diff --git a/virtio-devices/src/transport/pci_device.rs b/virtio-devices/src/transport/pci_device.rs
-index b51b33f7..b9c3ac35 100644
+index 95136aca..4da7c619 100644
 --- a/virtio-devices/src/transport/pci_device.rs
 +++ b/virtio-devices/src/transport/pci_device.rs
-@@ -1055,11 +1055,11 @@ impl PciDevice for VirtioPciDevice {
+@@ -1054,11 +1054,11 @@ impl PciDevice for VirtioPciDevice {
                      PciDeviceError::IoRegistrationFailed(shm_list.addr.raw_value(), e)
                  })?;
  
 -                for (idx, shm) in shm_list.region_list.iter().enumerate() {
 +                for (shmid, shm) in shm_list.region_list.iter() {
                      let shm_cap = VirtioPciCap64::new(
-                         PciCapabilityType::SharedMemoryConfig,
+                         PciCapabilityType::SharedMemory,
                          VIRTIO_SHM_BAR_INDEX as u8,
 -                        idx as u8,
 +                        *shmid,
@@ -204,28 +216,29 @@ index b51b33f7..b9c3ac35 100644
                      );
 diff --git a/virtio-devices/src/vhost_user/gpu.rs b/virtio-devices/src/vhost_user/gpu.rs
 new file mode 100644
-index 00000000..42703431
+index 00000000..416d9629
 --- /dev/null
 +++ b/virtio-devices/src/vhost_user/gpu.rs
-@@ -0,0 +1,373 @@
+@@ -0,0 +1,406 @@
 +// Copyright 2019 Intel Corporation. All Rights Reserved.
 +// Copyright 2022 Unikie
-+// Copyright 2022 Puck Meerburg
 +// Copyright 2023 Alyssa Ross <hi@alyssa.is>
 +// SPDX-License-Identifier: Apache-2.0
 +
++use super::vu_common_ctrl::VhostUserHandle;
++use super::{Error, Result};
 +use crate::seccomp_filters::Thread;
 +use crate::thread_helper::spawn_virtio_thread;
-+use crate::vhost_user::vu_common_ctrl::VhostUserHandle;
-+use crate::vhost_user::{Error, Result, VhostUserCommon};
++use crate::vhost_user::VhostUserCommon;
 +use crate::{
-+    ActivateError, ActivateResult, GuestMemoryMmap, GuestRegionMmap, MmapRegion, UserspaceMapping,
-+    VirtioCommon, VirtioDevice, VirtioDeviceType, VirtioInterrupt, VirtioSharedMemoryList,
-+    VIRTIO_F_VERSION_1,
++    ActivateError, ActivateResult, UserspaceMapping, VirtioCommon, VirtioDevice, VirtioDeviceType,
++    VirtioInterrupt, VirtioSharedMemoryList, VIRTIO_F_IOMMU_PLATFORM, VIRTIO_F_VERSION_1,
 +};
++use crate::{GuestMemoryMmap, GuestRegionMmap, MmapRegion};
 +use seccompiler::SeccompAction;
 +use std::io::{self, Write};
-+use std::os::unix::prelude::AsRawFd;
++use std::os::unix::io::AsRawFd;
++use std::result;
 +use std::sync::{Arc, Barrier, Mutex};
 +use std::thread;
 +use vhost::vhost_user::message::{
@@ -241,7 +254,7 @@ index 00000000..42703431
 +};
 +use virtio_queue::Queue;
 +use vm_memory::GuestMemoryAtomic;
-+use vm_migration::Pausable;
++use vm_migration::{MigratableError, Pausable};
 +use vmm_sys_util::eventfd::EventFd;
 +
 +const QUEUE_SIZES: &[u16] = &[256, 16];
@@ -271,29 +284,21 @@ index 00000000..42703431
 +        }
 +
 +        let addr = self.mmap_cache_addr + req.shm_offset;
-+        let mut ret = unsafe {
++        let ret = unsafe {
 +            libc::mmap(
 +                addr as *mut libc::c_void,
 +                req.len as usize,
 +                req.flags.bits() as i32,
-+                libc::MAP_SHARED | libc::MAP_FIXED,
++                // https://bugzilla.kernel.org/show_bug.cgi?id=217238
++                if req.flags.bits() as i32 & libc::PROT_WRITE != 0 {
++                    libc::MAP_SHARED
++                } else {
++                    libc::MAP_PRIVATE
++                } | libc::MAP_FIXED,
 +                fd.as_raw_fd(),
 +                req.fd_offset as libc::off_t,
 +            )
 +        };
-+
-+        if ret == libc::MAP_FAILED {
-+            ret = unsafe {
-+                libc::mmap(
-+                    addr as *mut libc::c_void,
-+                    req.len as usize,
-+                    (req.flags.bits() as i32) & !libc::PROT_WRITE,
-+                    libc::MAP_SHARED | libc::MAP_FIXED,
-+                    fd.as_raw_fd(),
-+                    req.fd_offset as libc::off_t,
-+                )
-+            };
-+        }
 +
 +        if ret == libc::MAP_FAILED {
 +            return Err(io::Error::last_os_error());
@@ -343,9 +348,11 @@ index 00000000..42703431
 +    // which will be automatically dropped when the device is dropped
 +    cache: Option<(VirtioSharedMemoryList, MmapRegion)>,
 +    slave_req_support: bool,
-+    epoll_thread: Option<thread::JoinHandle<()>>,
 +    seccomp_action: SeccompAction,
++    guest_memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
++    epoll_thread: Option<thread::JoinHandle<()>>,
 +    exit_evt: EventFd,
++    iommu: bool,
 +}
 +
 +impl Gpu {
@@ -399,13 +406,15 @@ index 00000000..42703431
 +                ..Default::default()
 +            },
 +            id,
++            cache,
 +            slave_req_support: acked_protocol_features
 +                & VhostUserProtocolFeatures::SLAVE_REQ.bits()
 +                != 0,
-+            cache,
 +            seccomp_action,
++            guest_memory: None,
 +            epoll_thread: None,
 +            exit_evt,
++            iommu,
 +        })
 +    }
 +}
@@ -429,7 +438,11 @@ index 00000000..42703431
 +    }
 +
 +    fn features(&self) -> u64 {
-+        self.common.avail_features
++        let mut features = self.common.avail_features;
++        if self.iommu {
++            features |= 1u64 << VIRTIO_F_IOMMU_PLATFORM;
++        }
++        features
 +    }
 +
 +    fn ack_features(&mut self, value: u64) {
@@ -452,8 +465,6 @@ index 00000000..42703431
 +                .and_then(|(_, config)| data.write_all(&config).map_err(|e| format!("{:?}", e)))
 +            {
 +                error!("Failed getting vhost-user-gpu configuration: {:?}", e);
-+            } else {
-+                eprintln!("read_config({}, {:?})", offset, data);
 +            }
 +        }
 +    }
@@ -465,6 +476,7 @@ index 00000000..42703431
 +        queues: Vec<(usize, Queue, EventFd)>,
 +    ) -> ActivateResult {
 +        self.common.activate(&queues, &interrupt_cb)?;
++        self.guest_memory = Some(mem.clone());
 +
 +        // Initialize slave communication.
 +        let slave_req_handler = if self.slave_req_support {
@@ -567,22 +579,55 @@ index 00000000..42703431
 +        &mut self,
 +        shm_regions: VirtioSharedMemoryList,
 +    ) -> std::result::Result<(), crate::Error> {
-+        todo!("set_shm_regions({:?})", shm_regions)
++        if let Some(cache) = self.cache.as_mut() {
++            cache.0 = shm_regions;
++            Ok(())
++        } else {
++            Err(crate::Error::SetShmRegionsNotSupported)
++        }
 +    }
 +
 +    fn add_memory_region(
 +        &mut self,
 +        region: &Arc<GuestRegionMmap>,
 +    ) -> std::result::Result<(), crate::Error> {
-+        todo!("add_memory_region({:?})", region)
++        self.vu_common.add_memory_region(&self.guest_memory, region)
 +    }
 +
 +    fn userspace_mappings(&self) -> Vec<UserspaceMapping> {
-+        todo!()
++        let mut mappings = Vec::new();
++        if let Some(cache) = self.cache.as_ref() {
++            mappings.push(UserspaceMapping {
++                host_addr: cache.0.host_addr,
++                mem_slot: cache.0.mem_slot,
++                addr: cache.0.addr,
++                len: cache.0.len,
++                mergeable: false,
++            })
++        }
++
++        mappings
++    }
++}
++
++impl Pausable for Gpu {
++    fn pause(&mut self) -> result::Result<(), MigratableError> {
++        self.vu_common.pause()?;
++        self.common.pause()
++    }
++
++    fn resume(&mut self) -> result::Result<(), MigratableError> {
++        self.common.resume()?;
++
++        if let Some(epoll_thread) = &self.epoll_thread {
++            epoll_thread.thread().unpark();
++        }
++
++        self.vu_common.resume()
 +    }
 +}
 diff --git a/virtio-devices/src/vhost_user/mod.rs b/virtio-devices/src/vhost_user/mod.rs
-index 6ad88b44..981eca93 100644
+index a31e523c..8b1baa8c 100644
 --- a/virtio-devices/src/vhost_user/mod.rs
 +++ b/virtio-devices/src/vhost_user/mod.rs
 @@ -31,11 +31,13 @@ use vu_common_ctrl::VhostUserHandle;
@@ -599,63 +644,34 @@ index 6ad88b44..981eca93 100644
  pub use self::net::Net;
  pub use self::vu_common_ctrl::VhostUserConfig;
  
-diff --git a/virtio-devices/src/vhost_user/vu_common_ctrl.rs b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
-index 7bbf936c..68d3a521 100644
---- a/virtio-devices/src/vhost_user/vu_common_ctrl.rs
-+++ b/virtio-devices/src/vhost_user/vu_common_ctrl.rs
-@@ -199,6 +199,14 @@ impl VhostUserHandle {
-                 .map_err(Error::VhostUserSetInflight)?;
-         }
- 
-+        // FIXME: crosvm's vhost-user backend requires this to come first.
-+        // Can we fix that in crosvm?
-+        if let Some(slave_req_handler) = slave_req_handler {
-+            self.vu
-+                .set_slave_request_fd(&slave_req_handler.get_tx_raw_fd())
-+                .map_err(Error::VhostUserSetSlaveRequestFd)?;
-+        }
-+
-         let mut vrings_info = Vec::new();
-         for (queue_index, queue, queue_evt) in queues.iter() {
-             let actual_size: usize = queue.size().try_into().unwrap();
-@@ -267,12 +275,6 @@ impl VhostUserHandle {
- 
-         self.enable_vhost_user_vrings(self.queue_indexes.clone(), true)?;
- 
--        if let Some(slave_req_handler) = slave_req_handler {
--            self.vu
--                .set_slave_request_fd(&slave_req_handler.get_tx_raw_fd())
--                .map_err(Error::VhostUserSetSlaveRequestFd)?;
--        }
--
-         self.vrings_info = Some(vrings_info);
-         self.ready = true;
- 
 diff --git a/vmm/Cargo.toml b/vmm/Cargo.toml
-index a2ef658e..305b439e 100644
+index 15a6a06a..e8379c1a 100644
 --- a/vmm/Cargo.toml
 +++ b/vmm/Cargo.toml
-@@ -47,6 +47,7 @@ versionize_derive = "0.1.4"
+@@ -49,6 +49,7 @@ versionize = "0.1.10"
+ versionize_derive = "0.1.4"
  vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
  vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }
- vhdx = { path = "../vhdx" }
 +virtio-bindings = "0.2.0"
  virtio-devices = { path = "../virtio-devices" }
- virtio-queue = "0.7.0"
+ virtio-queue = "0.8.0"
  vm-allocator = { path = "../vm-allocator" }
 diff --git a/vmm/src/api/mod.rs b/vmm/src/api/mod.rs
-index c1b5ef0d..17520216 100644
+index 8aac5d3c..041a6c41 100644
 --- a/vmm/src/api/mod.rs
 +++ b/vmm/src/api/mod.rs
-@@ -34,6 +34,7 @@ pub use self::http::start_http_path_thread;
- pub mod http;
- pub mod http_endpoint;
+@@ -38,8 +38,8 @@ pub use self::http::start_http_fd_thread;
+ pub use self::http::start_http_path_thread;
  
-+use crate::config::GpuConfig;
  use crate::config::{
-     DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, RestoreConfig, UserDeviceConfig,
-     VdpaConfig, VmConfig, VsockConfig,
-@@ -132,6 +133,9 @@ pub enum ApiError {
+-    DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, RestoreConfig, UserDeviceConfig,
+-    VdpaConfig, VmConfig, VsockConfig,
++    DeviceConfig, DiskConfig, FsConfig, GpuConfig, NetConfig, PmemConfig, RestoreConfig,
++    UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
+ };
+ use crate::device_tree::DeviceTree;
+ use crate::vm::{Error as VmError, VmState};
+@@ -135,6 +135,9 @@ pub enum ApiError {
      /// The fs could not be added to the VM.
      VmAddFs(VmError),
  
@@ -665,7 +681,7 @@ index c1b5ef0d..17520216 100644
      /// The pmem device could not be added to the VM.
      VmAddPmem(VmError),
  
-@@ -301,6 +305,9 @@ pub enum ApiRequest {
+@@ -305,6 +308,9 @@ pub enum ApiRequest {
      /// Add a fs to the VM.
      VmAddFs(Arc<FsConfig>, Sender<ApiResponse>),
  
@@ -676,7 +692,7 @@ index c1b5ef0d..17520216 100644
      VmAddPmem(Arc<PmemConfig>, Sender<ApiResponse>),
  
 diff --git a/vmm/src/config.rs b/vmm/src/config.rs
-index f2476da8..a878b351 100644
+index ecb8493a..6cabc573 100644
 --- a/vmm/src/config.rs
 +++ b/vmm/src/config.rs
 @@ -26,6 +26,8 @@ pub enum Error {
@@ -697,17 +713,15 @@ index f2476da8..a878b351 100644
      /// Error parsing persistent memory parameters
      ParsePersistentMemory(OptionParserError),
      /// Failed parsing console
-@@ -301,7 +305,9 @@ impl fmt::Display for Error {
+@@ -301,6 +305,8 @@ impl fmt::Display for Error {
              ParseFileSystem(o) => write!(f, "Error parsing --fs: {o}"),
              ParseFsSockMissing => write!(f, "Error parsing --fs: socket missing"),
              ParseFsTagMissing => write!(f, "Error parsing --fs: tag missing"),
--            ParsePersistentMemory(o) => write!(f, "Error parsing --pmem: {o}"),
 +            ParseGpu(o) => write!(f, "Error parsing --gpu: {o}"),
 +            ParseGpuSockMissing => write!(f, "Error parsing --gpu: socket missing"),
-+            ParsePersistentMemory(o) => write!(f, "Error parsing --pmem: {}", o),
+             ParsePersistentMemory(o) => write!(f, "Error parsing --pmem: {o}"),
              ParsePmemFileMissing => write!(f, "Error parsing --pmem: file missing"),
              ParseVsock(o) => write!(f, "Error parsing --vsock: {o}"),
-             ParseVsockCidMissing => write!(f, "Error parsing --vsock: cid missing"),
 @@ -363,6 +369,7 @@ pub struct VmParams<'a> {
      pub rng: &'a str,
      pub balloon: Option<&'a str>,
@@ -716,7 +730,7 @@ index f2476da8..a878b351 100644
      pub pmem: Option<Vec<&'a str>>,
      pub serial: &'a str,
      pub console: &'a str,
-@@ -1285,6 +1292,56 @@ impl FsConfig {
+@@ -1254,6 +1261,56 @@ impl FsConfig {
      }
  }
  
@@ -773,7 +787,7 @@ index f2476da8..a878b351 100644
  impl PmemConfig {
      pub fn parse(pmem: &str) -> Result<Self> {
          let mut parser = OptionParser::new();
-@@ -1818,6 +1875,17 @@ impl VmConfig {
+@@ -1787,6 +1844,17 @@ impl VmConfig {
              }
          }
  
@@ -791,7 +805,7 @@ index f2476da8..a878b351 100644
          if let Some(pmems) = &self.pmem {
              for pmem in pmems {
                  pmem.validate(self)?;
-@@ -2003,6 +2071,15 @@ impl VmConfig {
+@@ -1972,6 +2040,15 @@ impl VmConfig {
              fs = Some(fs_config_list);
          }
  
@@ -807,7 +821,7 @@ index f2476da8..a878b351 100644
          let mut pmem: Option<Vec<PmemConfig>> = None;
          if let Some(pmem_list) = &vm_params.pmem {
              let mut pmem_config_list = Vec::new();
-@@ -2109,6 +2186,7 @@ impl VmConfig {
+@@ -2078,6 +2155,7 @@ impl VmConfig {
              rng,
              balloon,
              fs,
@@ -815,7 +829,29 @@ index f2476da8..a878b351 100644
              pmem,
              serial,
              console,
-@@ -2516,6 +2594,21 @@ mod tests {
+@@ -2132,6 +2210,13 @@ impl VmConfig {
+             removed |= fs.len() != len;
+         }
+ 
++        // Remove if gpu device
++        if let Some(gpu) = self.gpu.as_mut() {
++            let len = gpu.len();
++            gpu.retain(|dev| dev.id.as_ref().map(|id| id.as_ref()) != Some(id));
++            removed |= gpu.len() != len;
++        }
++
+         // Remove if net device
+         if let Some(net) = self.net.as_mut() {
+             let len = net.len();
+@@ -2196,6 +2281,7 @@ impl Clone for VmConfig {
+             rng: self.rng.clone(),
+             balloon: self.balloon.clone(),
+             fs: self.fs.clone(),
++            gpu: self.gpu.clone(),
+             pmem: self.pmem.clone(),
+             serial: self.serial.clone(),
+             console: self.console.clone(),
+@@ -2583,6 +2669,21 @@ mod tests {
          Ok(())
      }
  
@@ -837,7 +873,7 @@ index f2476da8..a878b351 100644
      #[test]
      fn test_pmem_parsing() -> Result<()> {
          // Must always give a file and size
-@@ -2750,6 +2843,7 @@ mod tests {
+@@ -2817,6 +2918,7 @@ mod tests {
              },
              balloon: None,
              fs: None,
@@ -845,7 +881,7 @@ index f2476da8..a878b351 100644
              pmem: None,
              serial: ConsoleConfig {
                  file: None,
-@@ -2927,6 +3021,15 @@ mod tests {
+@@ -2982,6 +3084,15 @@ mod tests {
              Err(ValidationError::VhostUserRequiresSharedMemory)
          );
  
@@ -862,7 +898,7 @@ index f2476da8..a878b351 100644
          still_valid_config.memory.shared = true;
          assert!(still_valid_config.validate().is_ok());
 diff --git a/vmm/src/device_manager.rs b/vmm/src/device_manager.rs
-index 76ca3775..1cec7c6a 100644
+index 8c3f58c6..3c647db4 100644
 --- a/vmm/src/device_manager.rs
 +++ b/vmm/src/device_manager.rs
 @@ -10,8 +10,8 @@
@@ -876,7 +912,7 @@ index 76ca3775..1cec7c6a 100644
  };
  use crate::cpu::{CpuManager, CPU_MANAGER_ACPI_SIZE};
  use crate::device_tree::{DeviceNode, DeviceTree};
-@@ -64,6 +64,7 @@ use serde::{Deserialize, Serialize};
+@@ -66,6 +66,7 @@ use serde::{Deserialize, Serialize};
  use std::collections::{BTreeSet, HashMap};
  use std::fs::{read_link, File, OpenOptions};
  use std::io::{self, stdout, Seek, SeekFrom};
@@ -884,7 +920,7 @@ index 76ca3775..1cec7c6a 100644
  use std::mem::zeroed;
  use std::num::Wrapping;
  use std::os::unix::fs::OpenOptionsExt;
-@@ -74,11 +75,13 @@ use std::sync::{Arc, Mutex};
+@@ -76,11 +77,13 @@ use std::sync::{Arc, Mutex};
  use std::time::Instant;
  use tracer::trace_scoped;
  use vfio_ioctls::{VfioContainer, VfioDevice, VfioDeviceFd};
@@ -898,7 +934,7 @@ index 76ca3775..1cec7c6a 100644
  };
  use virtio_devices::{Endpoint, IommuMapping};
  use vm_allocator::{AddressAllocator, SystemAllocator};
-@@ -119,6 +122,7 @@ const CONSOLE_DEVICE_NAME: &str = "__console";
+@@ -122,6 +125,7 @@ const PVPANIC_DEVICE_NAME: &str = "__pvpanic";
  // identifiers if the user doesn't give one
  const DISK_DEVICE_NAME_PREFIX: &str = "_disk";
  const FS_DEVICE_NAME_PREFIX: &str = "_fs";
@@ -906,7 +942,7 @@ index 76ca3775..1cec7c6a 100644
  const NET_DEVICE_NAME_PREFIX: &str = "_net";
  const PMEM_DEVICE_NAME_PREFIX: &str = "_pmem";
  const VDPA_DEVICE_NAME_PREFIX: &str = "_vdpa";
-@@ -155,9 +159,15 @@ pub enum DeviceManagerError {
+@@ -158,9 +162,15 @@ pub enum DeviceManagerError {
      /// Cannot create virtio-fs device
      CreateVirtioFs(virtio_devices::vhost_user::Error),
  
@@ -922,7 +958,7 @@ index 76ca3775..1cec7c6a 100644
      /// Cannot create vhost-user-blk device
      CreateVhostUserBlk(virtio_devices::vhost_user::Error),
  
-@@ -242,6 +252,9 @@ pub enum DeviceManagerError {
+@@ -245,6 +255,9 @@ pub enum DeviceManagerError {
      /// Cannot find a memory range for virtio-fs
      FsRangeAllocation,
  
@@ -932,7 +968,7 @@ index 76ca3775..1cec7c6a 100644
      /// Error creating serial output file
      SerialOutputFileOpen(io::Error),
  
-@@ -2085,6 +2098,9 @@ impl DeviceManager {
+@@ -2140,6 +2153,9 @@ impl DeviceManager {
          // Add virtio-fs if required
          devices.append(&mut self.make_virtio_fs_devices()?);
  
@@ -942,7 +978,7 @@ index 76ca3775..1cec7c6a 100644
          // Add virtio-pmem if required
          devices.append(&mut self.make_virtio_pmem_devices()?);
  
-@@ -2576,6 +2592,118 @@ impl DeviceManager {
+@@ -2654,6 +2670,118 @@ impl DeviceManager {
          Ok(devices)
      }
  
@@ -1061,7 +1097,15 @@ index 76ca3775..1cec7c6a 100644
      fn make_virtio_pmem_device(
          &mut self,
          pmem_cfg: &mut PmemConfig,
-@@ -4066,6 +4194,13 @@ impl DeviceManager {
+@@ -3913,6 +4041,7 @@ impl DeviceManager {
+                 | VirtioDeviceType::Block
+                 | VirtioDeviceType::Pmem
+                 | VirtioDeviceType::Fs
++                | VirtioDeviceType::Gpu
+                 | VirtioDeviceType::Vsock => {}
+                 _ => return Err(DeviceManagerError::RemovalNotAllowed(device_type)),
+             }
+@@ -4181,6 +4310,13 @@ impl DeviceManager {
          self.hotplug_virtio_pci_device(device)
      }
  
@@ -1076,18 +1120,30 @@ index 76ca3775..1cec7c6a 100644
          self.validate_identifier(&pmem_cfg.id)?;
  
 diff --git a/vmm/src/lib.rs b/vmm/src/lib.rs
-index a25cab35..6a1b4a82 100644
+index 7cad2ca4..e9129b48 100644
 --- a/vmm/src/lib.rs
 +++ b/vmm/src/lib.rs
-@@ -25,6 +25,7 @@ use crate::migration::{recv_vm_config, recv_vm_state};
+@@ -13,8 +13,8 @@ use crate::api::{
+     VmSendMigrationData, VmmPingResponse,
+ };
+ use crate::config::{
+-    add_to_config, DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, RestoreConfig,
+-    UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
++    add_to_config, DeviceConfig, DiskConfig, FsConfig, GpuConfig, NetConfig, PmemConfig,
++    RestoreConfig, UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
+ };
+ #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
+ use crate::coredump::GuestDebuggable;
+@@ -25,8 +25,6 @@ use crate::migration::{recv_vm_config, recv_vm_state};
  use crate::seccomp_filters::{get_seccomp_filter, Thread};
  use crate::vm::{Error as VmError, Vm, VmState};
  use anyhow::anyhow;
-+use config::GpuConfig;
- use libc::{EFD_NONBLOCK, SIGINT, SIGTERM};
+-#[cfg(feature = "dbus_api")]
+-use api::dbus::{DBusApiOptions, DBusApiShutdownChannels};
+ use libc::{tcsetattr, termios, EFD_NONBLOCK, SIGINT, SIGTERM, TCSANOW};
  use memory_manager::MemoryManagerSnapshotData;
  use pci::PciBdf;
-@@ -1013,6 +1014,32 @@ impl Vmm {
+@@ -1139,6 +1137,32 @@ impl Vmm {
          }
      }
  
@@ -1120,7 +1176,7 @@ index a25cab35..6a1b4a82 100644
      fn vm_add_pmem(&mut self, pmem_cfg: PmemConfig) -> result::Result<Option<Vec<u8>>, VmError> {
          self.vm_config.as_ref().ok_or(VmError::VmNotCreated)?;
  
-@@ -1941,6 +1968,13 @@ impl Vmm {
+@@ -2070,6 +2094,13 @@ impl Vmm {
                                          .map(ApiResponsePayload::VmAction);
                                      sender.send(response).map_err(Error::ApiResponseSend)?;
                                  }
@@ -1134,7 +1190,7 @@ index a25cab35..6a1b4a82 100644
                                  ApiRequest::VmAddPmem(add_pmem_data, sender) => {
                                      let response = self
                                          .vm_add_pmem(add_pmem_data.as_ref().clone())
-@@ -2106,6 +2140,7 @@ mod unit_tests {
+@@ -2235,6 +2266,7 @@ mod unit_tests {
              },
              balloon: None,
              fs: None,
@@ -1142,7 +1198,7 @@ index a25cab35..6a1b4a82 100644
              pmem: None,
              serial: ConsoleConfig {
                  file: None,
-@@ -2331,6 +2366,54 @@ mod unit_tests {
+@@ -2462,6 +2494,54 @@ mod unit_tests {
          );
      }
  
@@ -1198,7 +1254,7 @@ index a25cab35..6a1b4a82 100644
      fn test_vmm_vm_cold_add_pmem() {
          let mut vmm = create_dummy_vmm();
 diff --git a/vmm/src/vm.rs b/vmm/src/vm.rs
-index 21417309..2e23a48a 100644
+index 078bdd8a..82f089a3 100644
 --- a/vmm/src/vm.rs
 +++ b/vmm/src/vm.rs
 @@ -12,8 +12,8 @@
@@ -1212,19 +1268,7 @@ index 21417309..2e23a48a 100644
  };
  use crate::config::{NumaConfig, PayloadConfig};
  #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
-@@ -1454,6 +1454,11 @@ impl Vm {
-             fs.retain(|dev| dev.id.as_ref() != Some(&id));
-         }
- 
-+        // Remove if gpu device
-+        if let Some(gpu) = config.gpu.as_mut() {
-+            gpu.retain(|dev| dev.id.as_ref() != Some(&id));
-+        }
-+
-         // Remove if net device
-         if let Some(net) = config.net.as_mut() {
-             net.retain(|dev| dev.id.as_ref() != Some(&id));
-@@ -1532,6 +1537,30 @@ impl Vm {
+@@ -1467,6 +1467,30 @@ impl Vm {
          Ok(pci_device_info)
      }
  
@@ -1256,10 +1300,10 @@ index 21417309..2e23a48a 100644
          let pci_device_info = self
              .device_manager
 diff --git a/vmm/src/vm_config.rs b/vmm/src/vm_config.rs
-index ed7e4c10..f733979a 100644
+index a51add7b..afc819a4 100644
 --- a/vmm/src/vm_config.rs
 +++ b/vmm/src/vm_config.rs
-@@ -411,6 +411,30 @@ impl Default for FsConfig {
+@@ -411,6 +411,32 @@ impl Default for FsConfig {
      }
  }
  
@@ -1268,7 +1312,9 @@ index ed7e4c10..f733979a 100644
 +    pub socket: PathBuf,
 +    #[serde(default = "default_gpuconfig_cache_size")]
 +    pub cache_size: u64,
++    #[serde(default)]
 +    pub id: Option<String>,
++    #[serde(default)]
 +    pub pci_segment: u16,
 +}
 +
@@ -1290,7 +1336,7 @@ index ed7e4c10..f733979a 100644
  #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
  pub struct PmemConfig {
      pub file: PathBuf,
-@@ -576,6 +600,7 @@ pub struct VmConfig {
+@@ -576,6 +602,7 @@ pub struct VmConfig {
      pub rng: RngConfig,
      pub balloon: Option<BalloonConfig>,
      pub fs: Option<Vec<FsConfig>>,
@@ -1299,5 +1345,5 @@ index ed7e4c10..f733979a 100644
      #[serde(default = "default_serial")]
      pub serial: ConsoleConfig,
 -- 
-2.37.1
+2.42.0
 

--- a/pkgs/spectrum-os/cloud-hypervisor/Cargo.lock
+++ b/pkgs/spectrum-os/cloud-hypervisor/Cargo.lock
@@ -5,9 +5,9 @@ version = 3
 [[package]]
 name = "acpi_tables"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#12bb6d7b252831527e630f8b3ef48877dbb11924"
+source = "git+https://github.com/rust-vmm/acpi_tables?branch=main#05a609136387cc1cc9b499cee4320020325c263f"
 dependencies = [
- "vm-memory",
+ "zerocopy",
 ]
 
 [[package]]
@@ -27,18 +27,18 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "api_client"
@@ -94,7 +94,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -102,6 +102,134 @@ name = "argh_shared"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cb94155d965e3d37ffbbe7cc5b82c3dd79dd33bd48e536f73d2cfb8d85506f"
+
+[[package]]
+name = "async-broadcast"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+dependencies = [
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
+dependencies = [
+ "async-lock",
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite",
+ "log",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "socket2",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-process"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "async-task"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
+
+[[package]]
+name = "async-trait"
+version = "0.1.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
 name = "autocfg"
@@ -140,24 +268,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "block_util"
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
+name = "block"
 version = "0.1.0"
 dependencies = [
+ "byteorder",
+ "crc32c",
  "io-uring",
  "libc",
  "log",
- "qcow",
+ "remain",
  "smallvec",
  "thiserror",
+ "uuid",
  "versionize",
  "versionize_derive",
- "vhdx",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "virtio-queue",
  "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
 ]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "log",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -179,7 +345,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cloud-hypervisor"
-version = "30.0.0"
+version = "34.0.0"
 dependencies = [
  "anyhow",
  "api_client",
@@ -205,6 +371,25 @@ dependencies = [
  "vmm",
  "vmm-sys-util",
  "wait-timeout",
+ "zbus",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -223,10 +408,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55626594feae15d266d52440b26ff77de0e22230cf0c113abe619084c1ddc910"
 
 [[package]]
-name = "darling"
-version = "0.14.3"
+name = "crossbeam-utils"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -234,27 +438,38 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.3"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.3"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -264,15 +479,18 @@ dependencies = [
  "acpi_tables",
  "anyhow",
  "arch",
- "bitflags",
+ "bitflags 2.3.3",
  "byteorder",
+ "event_monitor",
  "hypervisor",
  "libc",
  "log",
+ "pci",
  "thiserror",
  "tpm",
  "versionize",
  "versionize_derive",
+ "vm-allocator",
  "vm-device",
  "vm-memory",
  "vm-migration",
@@ -296,23 +514,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
+name = "digest"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c041f5090df68b32bcd905365fd51769c8b9d553fe87fde0b683534f10c01bd2"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -330,23 +580,23 @@ dependencies = [
 
 [[package]]
 name = "epoll"
-version = "4.3.1"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20df693c700404f7e19d4d6fae6b15215d2913c27955d2b9d6f2c0f537511cd0"
+checksum = "74351c3392ea1ff6cd2628e0042d268ac2371cb613252ff383b6dfa50d22fa79"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "libc",
 ]
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -360,12 +610,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "event_monitor"
 version = "0.1.0"
 dependencies = [
+ "flume",
  "libc",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -375,18 +641,135 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "gdbstub"
-version = "0.6.3"
+name = "futures"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c95766e0414f8bfc1d07055574c621b67739466d6ba516c4fef8e99d30d2e6"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
- "bitflags",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "gdbstub"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e02bf1b1a624d96925c608f1b268d82a76cbc587ce9e59f7c755e9ea11c75c"
+dependencies = [
+ "bitflags 1.3.2",
  "cfg-if",
  "log",
  "managed",
@@ -405,21 +788,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.8"
+name = "generic-array"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.27.1"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -428,10 +823,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.1"
+name = "hashbrown"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "humantime"
@@ -463,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "iced-x86"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd04b950d75b3498320253b17fb92745b2cc79ead8814aede2f7c1bab858bec"
+checksum = "b7cc8d38244d84278262c8ebe6930cc44283d194cbabae2651f6112103802fb5"
 dependencies = [
  "lazy_static",
 ]
@@ -475,6 +882,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
 
 [[package]]
 name = "instant"
@@ -487,21 +904,22 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
+ "hermit-abi",
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "io-uring"
-version = "0.5.12"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c85eff7f7c8d3ab8c7ec87313c0c194bbaf4371bb7d40f80293ba01bce8264"
+checksum = "8b7b36074613a723279637061b40db993208908a94f10ccb14436ce735bc0f57"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -516,21 +934,30 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kvm-bindings"
@@ -545,8 +972,7 @@ dependencies = [
 [[package]]
 name = "kvm-ioctls"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8dc9c1896e5f144ec5d07169bc29f39a047686d29585a91f30489abfaeb6b"
+source = "git+https://github.com/rust-vmm/kvm-ioctls?branch=main#23a3bb045a467e60bb00328a0b13cea13b5815d0"
 dependencies = [
  "kvm-bindings",
  "libc",
@@ -561,9 +987,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libssh2-sys"
@@ -581,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
 dependencies = [
  "cc",
  "libc",
@@ -593,24 +1019,24 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9259ddbfbb52cc918f6bbc60390004ddd0228cf1d85f402009ff2b3d95de83f"
+checksum = "8d3adb7b28e189741eca3b1a4a27de0bf15e0907c9d4b0c74bd2d7d84ef72e08"
 dependencies = [
  "vm-memory",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -638,6 +1064,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "micro_http"
 version = "0.1.0"
 source = "git+https://github.com/firecracker-microvm/micro-http?branch=main#b538bf89e50be83b6fa9ab1896727ff61e02fa13"
@@ -648,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e212582ede878b109755efd0773a4f0f4ec851584cf0aefbeb4d9ecc114822"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -668,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "mshv-bindings"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#0b2af251285385f8e39c2cd0fe8ffacab534932f"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#a45fbeb4a3930a2d17142e5687fe2f667c2df529"
 dependencies = [
  "libc",
  "serde",
@@ -680,11 +1115,20 @@ dependencies = [
 [[package]]
 name = "mshv-ioctls"
 version = "0.1.1"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#0b2af251285385f8e39c2cd0fe8ffacab534932f"
+source = "git+https://github.com/rust-vmm/mshv?branch=main#a45fbeb4a3930a2d17142e5687fe2f667c2df529"
 dependencies = [
  "libc",
  "mshv-bindings",
  "vmm-sys-util",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -712,11 +1156,24 @@ dependencies = [
  "thiserror",
  "versionize",
  "versionize_derive",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "virtio-queue",
  "vm-memory",
  "vm-virtio",
  "vmm-sys-util",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "static_assertions",
 ]
 
 [[package]]
@@ -745,26 +1202,25 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl-src"
-version = "111.25.0+1.1.1t"
+version = "111.26.0+1.1.1u"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "openssl-src",
@@ -773,8 +1229,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "option_parser"
 version = "0.1.0"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
 name = "parking_lot"
@@ -794,7 +1272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.6",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -806,29 +1284,29 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pci"
@@ -867,10 +1345,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.26"
+name = "pin-project"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "pnet"
@@ -917,7 +1427,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -964,32 +1474,83 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.51"
+name = "polling"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "qcow"
-version = "0.1.0"
+name = "quote"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
- "byteorder",
- "libc",
- "log",
- "remain",
- "vmm-sys-util",
+ "proc-macro2",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.23"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "proc-macro2",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1007,7 +1568,16 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1017,15 +1587,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1034,26 +1616,26 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "remain"
-version = "0.2.6"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5704e2cda92fd54202f05430725317ba0ea7d0c96b246ca0a92e45177127ba3b"
+checksum = "bce3a7139d2ee67d07538ee5dba997364fbc243e7e7143e96eb830c74bfaa082"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -1072,29 +1654,29 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.37.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "62f25693a73057a1b4cb56179dd3c7ea21a7c6c5ee7d85781f5749b46f34b79c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seccompiler"
@@ -1107,35 +1689,35 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -1143,10 +1725,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "2.2.0"
+name = "serde_repr"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
 dependencies = [
  "serde",
  "serde_with_macros",
@@ -1154,14 +1747,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
+checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1169,10 +1762,21 @@ name = "serial_buffer"
 version = "0.1.0"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.14"
+name = "sha1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1188,10 +1792,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "ssh2"
@@ -1199,11 +1831,17 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7fe461910559f6d5604c3731d00d2aafc4a83d1665922e280f42f9a168d5455"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "libssh2-sys",
  "parking_lot 0.11.2",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1213,9 +1851,20 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1230,6 +1879,19 @@ checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1258,22 +1920,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1281,6 +1943,23 @@ name = "thousands"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
 
 [[package]]
 name = "tpm"
@@ -1307,16 +1986,64 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.6"
+name = "tracing"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "uds_windows"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce65604324d3cce9b966701489fbd0cf318cb1f7bd9dd07ac9a4ee6fb791930d"
+dependencies = [
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "uuid"
-version = "1.3.0"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 dependencies = [
  "getrandom",
 ]
@@ -1328,10 +2055,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "versionize"
-version = "0.1.9"
+name = "version_check"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e2495726cf917e7ba7ec8bf0f0fceab543dd38d0a4195ed6bef331e38a290f"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "versionize"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca4b7062e7e6d685901e815c35f9671e059de97c1c0905eeff8592f3fff442f"
 dependencies = [
  "bincode",
  "crc64",
@@ -1339,7 +2072,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_derive",
- "syn",
+ "syn 1.0.109",
  "versionize_derive",
  "vmm-sys-util",
 ]
@@ -1347,17 +2080,17 @@ dependencies = [
 [[package]]
 name = "versionize_derive"
 version = "0.1.4"
-source = "git+https://github.com/cloud-hypervisor/versionize_derive?branch=ch#ae35ef7a3ddabd3371ab8ac0193a383aff6e4b1b"
+source = "git+https://github.com/cloud-hypervisor/versionize_derive?branch=ch#e502b1d4aabab342386f0c53780d49f21a6a1df6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "vfio-bindings"
 version = "0.4.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#43439e056ddfa84a4f7906ee7f2f58be70505c08"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#89f8e77dd1a2829197ecde65b686bafcc8a1def4"
 dependencies = [
  "vmm-sys-util",
 ]
@@ -1365,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "vfio-ioctls"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vfio?branch=main#43439e056ddfa84a4f7906ee7f2f58be70505c08"
+source = "git+https://github.com/rust-vmm/vfio?branch=main#89f8e77dd1a2829197ecde65b686bafcc8a1def4"
 dependencies = [
  "byteorder",
  "kvm-bindings",
@@ -1383,9 +2116,9 @@ dependencies = [
 [[package]]
 name = "vfio_user"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vfio-user?branch=main#afbbd5722885e961ce12baea12efe01d52ce14b0"
+source = "git+https://github.com/rust-vmm/vfio-user?branch=main#eef6bec4d421f08ed1688fe67c5ea33aabbf5069"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "log",
  "serde",
@@ -1398,23 +2131,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "vhdx"
-version = "0.1.0"
-dependencies = [
- "byteorder",
- "crc32c",
- "libc",
- "log",
- "remain",
- "thiserror",
- "uuid",
-]
-
-[[package]]
 name = "vhost"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "vm-memory",
  "vmm-sys-util",
@@ -1422,14 +2142,12 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f237b91db4ac339d639fb43398b52d785fa51e3c7760ac9425148863c1f4303"
+version = "0.9.0"
 dependencies = [
  "libc",
  "log",
  "vhost",
- "virtio-bindings 0.1.0",
+ "virtio-bindings",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -1440,16 +2158,15 @@ name = "vhost_user_block"
 version = "0.1.0"
 dependencies = [
  "argh",
- "block_util",
+ "block",
  "env_logger",
  "epoll",
  "libc",
  "log",
  "option_parser",
- "qcow",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -1468,16 +2185,10 @@ dependencies = [
  "option_parser",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "vm-memory",
  "vmm-sys-util",
 ]
-
-[[package]]
-name = "virtio-bindings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 
 [[package]]
 name = "virtio-bindings"
@@ -1491,11 +2202,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
- "block_util",
+ "block",
  "byteorder",
  "epoll",
  "event_monitor",
- "io-uring",
  "libc",
  "log",
  "net_gen",
@@ -1510,7 +2220,7 @@ dependencies = [
  "versionize",
  "versionize_derive",
  "vhost",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "virtio-queue",
  "vm-allocator",
  "vm-device",
@@ -1522,12 +2232,12 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e927d93d54c365034fd7f31a5f458a1f540de4a37c52e892670dad9692173c"
+checksum = "91aebb1df33db33cbf04d4c2445e4f78d0b0c8e65acfd16a4ee95ef63ca252f8"
 dependencies = [
  "log",
- "virtio-bindings 0.1.0",
+ "virtio-bindings",
  "vm-memory",
  "vmm-sys-util",
 ]
@@ -1557,13 +2267,13 @@ dependencies = [
 [[package]]
 name = "vm-fdt"
 version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#c5a99ab71b130435927d19b50c85fcd5ce904a8c"
+source = "git+https://github.com/rust-vmm/vm-fdt?branch=main#77212bd0d62913e445c89376bcbbecd595afc5b1"
 
 [[package]]
 name = "vm-memory"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
+checksum = "9d6ea57fe00f9086c59eeeb68e102dd611686bc3c28520fa465996d4d4bdce07"
 dependencies = [
  "arc-swap",
  "libc",
@@ -1600,11 +2310,13 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "arch",
- "bitflags",
- "block_util",
+ "bitflags 2.3.3",
+ "block",
+ "blocking",
  "devices",
  "epoll",
  "event_monitor",
+ "futures",
  "gdbstub",
  "gdbstub_arch",
  "hypervisor",
@@ -1616,7 +2328,6 @@ dependencies = [
  "once_cell",
  "option_parser",
  "pci",
- "qcow",
  "seccompiler",
  "serde",
  "serde_json",
@@ -1629,8 +2340,7 @@ dependencies = [
  "versionize_derive",
  "vfio-ioctls",
  "vfio_user",
- "vhdx",
- "virtio-bindings 0.2.0",
+ "virtio-bindings",
  "virtio-devices",
  "virtio-queue",
  "vm-allocator",
@@ -1639,6 +2349,8 @@ dependencies = [
  "vm-migration",
  "vm-virtio",
  "vmm-sys-util",
+ "zbus",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1647,7 +2359,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd64fe09d8e880e600c324e7d664760a17f56e9672b7495a86381b49e4f72f46"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "serde",
  "serde_derive",
@@ -1663,10 +2375,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "winapi"
@@ -1701,84 +2473,220 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "xdg-home"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
+name = "zbus"
+version = "3.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31de390a2d872e4cd04edd71b425e29853f786dc99317ed72d73d6fcf5ebb948"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "byteorder",
+ "derivative",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "once_cell",
+ "ordered-stream",
+ "rand",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "winapi",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "3.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d1794a946878c0e807f55a397187c11fc7a038ba5d868e7db4f3bd7760bc9d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1798,5 +2706,43 @@ checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "zvariant"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c"
+dependencies = [
+ "byteorder",
+ "enumflags2",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]

--- a/pkgs/spectrum-os/cloud-hypervisor/vhost/0001-vhost_user-add-shared-memory-region-support.patch
+++ b/pkgs/spectrum-os/cloud-hypervisor/vhost/0001-vhost_user-add-shared-memory-region-support.patch
@@ -1,4 +1,4 @@
-From ad7be9c6a962c1bc0c2dce6dc633e24805ad9e31 Mon Sep 17 00:00:00 2001
+From 22c27c55300acc69a0409c5716371d3b914012c9 Mon Sep 17 00:00:00 2001
 From: David Stevens <stevensd@chromium.org>
 Date: Wed, 15 Jun 2022 16:45:12 +0900
 Subject: [PATCH 1/2] vhost_user: add shared memory region support
@@ -22,19 +22,47 @@ Tested-by: kokoro <noreply+kokoro@google.com>
 (cherry-picked from commit f436e2706011fa5f34dc415972434aa3299ebc43)
 Signed-off-by: Alyssa Ross <alyssa.ross@unikie.com>
 ---
- src/vhost_user/dummy_slave.rs        |   4 +
- src/vhost_user/master.rs             |  25 +++++
- src/vhost_user/master_req_handler.rs |  66 ++++++++++---
- src/vhost_user/message.rs            | 140 +++++++++++++++++++++++++--
- src/vhost_user/mod.rs                |   2 +-
- src/vhost_user/slave_fs_cache.rs     |  63 +++++++-----
- src/vhost_user/slave_req_handler.rs  |  27 +++++-
- 7 files changed, 277 insertions(+), 50 deletions(-)
+ crates/vhost-user-backend/src/handler.rs      |  10 +-
+ crates/vhost/src/vhost_user/dummy_slave.rs    |   4 +
+ crates/vhost/src/vhost_user/master.rs         |  25 ++++
+ .../src/vhost_user/master_req_handler.rs      |  57 ++++++--
+ crates/vhost/src/vhost_user/message.rs        | 136 +++++++++++++++++-
+ crates/vhost/src/vhost_user/slave_req.rs      |  20 ++-
+ .../vhost/src/vhost_user/slave_req_handler.rs |  15 ++
+ 7 files changed, 247 insertions(+), 20 deletions(-)
 
-diff --git a/src/vhost_user/dummy_slave.rs b/src/vhost_user/dummy_slave.rs
+diff --git a/crates/vhost-user-backend/src/handler.rs b/crates/vhost-user-backend/src/handler.rs
+index 15f07f0..10493b7 100644
+--- a/crates/vhost-user-backend/src/handler.rs
++++ b/crates/vhost-user-backend/src/handler.rs
+@@ -11,9 +11,9 @@ use std::sync::Arc;
+ use std::thread;
+ 
+ use vhost::vhost_user::message::{
+-    VhostUserConfigFlags, VhostUserMemoryRegion, VhostUserProtocolFeatures,
+-    VhostUserSingleMemoryRegion, VhostUserVirtioFeatures, VhostUserVringAddrFlags,
+-    VhostUserVringState,
++    VhostSharedMemoryRegion, VhostUserConfigFlags, VhostUserMemoryRegion,
++    VhostUserProtocolFeatures, VhostUserSingleMemoryRegion, VhostUserVirtioFeatures,
++    VhostUserVringAddrFlags, VhostUserVringState,
+ };
+ use vhost::vhost_user::{
+     Error as VhostUserError, Result as VhostUserResult, Slave, VhostUserSlaveReqHandlerMut,
+@@ -591,6 +591,10 @@ where
+ 
+         Ok(())
+     }
++
++    fn get_shared_memory_regions(&mut self) -> VhostUserResult<Vec<VhostSharedMemoryRegion>> {
++        Ok(Vec::new())
++    }
+ }
+ 
+ impl<S, V, B: Bitmap> Drop for VhostUserHandler<S, V, B> {
+diff --git a/crates/vhost/src/vhost_user/dummy_slave.rs b/crates/vhost/src/vhost_user/dummy_slave.rs
 index ae728a0..00a1ae8 100644
---- a/src/vhost_user/dummy_slave.rs
-+++ b/src/vhost_user/dummy_slave.rs
+--- a/crates/vhost/src/vhost_user/dummy_slave.rs
++++ b/crates/vhost/src/vhost_user/dummy_slave.rs
 @@ -291,4 +291,8 @@ impl VhostUserSlaveReqHandlerMut for DummySlaveReqHandler {
      fn remove_mem_region(&mut self, _region: &VhostUserSingleMemoryRegion) -> Result<()> {
          Ok(())
@@ -44,10 +72,10 @@ index ae728a0..00a1ae8 100644
 +        Ok(Vec::new())
 +    }
  }
-diff --git a/src/vhost_user/master.rs b/src/vhost_user/master.rs
-index 87fef33..deab6a7 100644
---- a/src/vhost_user/master.rs
-+++ b/src/vhost_user/master.rs
+diff --git a/crates/vhost/src/vhost_user/master.rs b/crates/vhost/src/vhost_user/master.rs
+index 8170718..60bb551 100644
+--- a/crates/vhost/src/vhost_user/master.rs
++++ b/crates/vhost/src/vhost_user/master.rs
 @@ -72,6 +72,9 @@ pub trait VhostUserMaster: VhostBackend {
  
      /// Remove a guest memory mapping from vhost.
@@ -87,28 +115,11 @@ index 87fef33..deab6a7 100644
  }
  
  impl AsRawFd for Master {
-diff --git a/src/vhost_user/master_req_handler.rs b/src/vhost_user/master_req_handler.rs
-index 0ecda4e..54cc280 100644
---- a/src/vhost_user/master_req_handler.rs
-+++ b/src/vhost_user/master_req_handler.rs
-@@ -17,7 +17,7 @@ use super::{Error, HandlerResult, Result};
- /// request services from masters. The [VhostUserMasterReqHandler] trait defines services provided
- /// by masters, and it's used both on the master side and slave side.
- /// - on the slave side, a stub forwarder implementing [VhostUserMasterReqHandler] will proxy
--///   service requests to masters. The [SlaveFsCacheReq] is an example stub forwarder.
-+///   service requests to masters. The [Slave] is an example stub forwarder.
- /// - on the master side, the [MasterReqHandler] will forward service requests to a handler
- ///   implementing [VhostUserMasterReqHandler].
- ///
-@@ -26,13 +26,23 @@ use super::{Error, HandlerResult, Result};
- ///
- /// [VhostUserMasterReqHandler]: trait.VhostUserMasterReqHandler.html
- /// [MasterReqHandler]: struct.MasterReqHandler.html
--/// [SlaveFsCacheReq]: struct.SlaveFsCacheReq.html
-+/// [Slave]: struct.Slave.html
- pub trait VhostUserMasterReqHandler {
-     /// Handle device configuration change notifications.
-     fn handle_config_change(&self) -> HandlerResult<u64> {
+diff --git a/crates/vhost/src/vhost_user/master_req_handler.rs b/crates/vhost/src/vhost_user/master_req_handler.rs
+index 4225ba6..b2d8c19 100644
+--- a/crates/vhost/src/vhost_user/master_req_handler.rs
++++ b/crates/vhost/src/vhost_user/master_req_handler.rs
+@@ -33,6 +33,16 @@ pub trait VhostUserMasterReqHandler {
          Err(std::io::Error::from_raw_os_error(libc::ENOSYS))
      }
  
@@ -161,20 +172,20 @@ index 0ecda4e..54cc280 100644
                      .handle_config_change()
                      .map_err(Error::ReqHandlerError)
              }
-+            SlaveReq::SHMEM_MAP => {
++            Ok(SlaveReq::SHMEM_MAP) => {
 +                let msg = self.extract_msg_body::<VhostUserShmemMapMsg>(&hdr, size, &buf)?;
 +                // check_attached_files() has validated files
 +                self.backend
 +                    .shmem_map(&msg, &files.unwrap()[0])
 +                    .map_err(Error::ReqHandlerError)
 +            }
-+            SlaveReq::SHMEM_UNMAP => {
++            Ok(SlaveReq::SHMEM_UNMAP) => {
 +                let msg = self.extract_msg_body::<VhostUserShmemUnmapMsg>(&hdr, size, &buf)?;
 +                self.backend
 +                    .shmem_unmap(&msg)
 +                    .map_err(Error::ReqHandlerError)
 +            }
-             SlaveReq::FS_MAP => {
+             Ok(SlaveReq::FS_MAP) => {
                  let msg = self.extract_msg_body::<VhostUserFSSlaveMsg>(&hdr, size, &buf)?;
                  // check_attached_files() has validated files
 @@ -251,7 +292,7 @@ impl<S: VhostUserMasterReqHandler> MasterReqHandler<S> {
@@ -190,12 +201,12 @@ index 0ecda4e..54cc280 100644
          files: &Option<Vec<File>>,
      ) -> Result<()> {
          match hdr.get_code() {
--            SlaveReq::FS_MAP | SlaveReq::FS_IO => {
-+            SlaveReq::SHMEM_MAP | SlaveReq::FS_MAP | SlaveReq::FS_IO => {
+-            Ok(SlaveReq::FS_MAP | SlaveReq::FS_IO) => {
++            Ok(SlaveReq::SHMEM_MAP | SlaveReq::FS_MAP | SlaveReq::FS_IO) => {
                  // Expect a single file is passed.
                  match files {
                      Some(files) if files.len() == 1 => Ok(()),
-@@ -326,12 +367,11 @@ impl<S: VhostUserMasterReqHandler> MasterReqHandler<S> {
+@@ -326,12 +367,12 @@ impl<S: VhostUserMasterReqHandler> MasterReqHandler<S> {
          ))
      }
  
@@ -206,45 +217,19 @@ index 0ecda4e..54cc280 100644
 -    ) -> Result<()> {
 -        if self.reply_ack_negotiated && req.is_need_reply() {
 +    fn send_reply(&mut self, req: &VhostUserMsgHeader<SlaveReq>, res: &Result<u64>) -> Result<()> {
-+        if req.get_code() == SlaveReq::SHMEM_MAP
-+            || req.get_code() == SlaveReq::SHMEM_UNMAP
-+            || (self.reply_ack_negotiated && req.is_need_reply())
++        if matches!(
++            req.get_code(),
++            Ok(SlaveReq::SHMEM_MAP | SlaveReq::SHMEM_UNMAP)
++        ) || (self.reply_ack_negotiated && req.is_need_reply())
 +        {
              let hdr = self.new_reply_header::<VhostUserU64>(req)?;
              let def_err = libc::EINVAL;
              let val = match res {
-@@ -362,7 +402,7 @@ mod tests {
-     use super::*;
- 
-     #[cfg(feature = "vhost-user-slave")]
--    use crate::vhost_user::SlaveFsCacheReq;
-+    use crate::vhost_user::Slave;
-     #[cfg(feature = "vhost-user-slave")]
-     use std::os::unix::io::FromRawFd;
- 
-@@ -410,7 +450,7 @@ mod tests {
-             panic!("failed to duplicated tx fd!");
-         }
-         let stream = unsafe { UnixStream::from_raw_fd(fd) };
--        let fs_cache = SlaveFsCacheReq::from_stream(stream);
-+        let fs_cache = Slave::from_stream(stream);
- 
-         std::thread::spawn(move || {
-             let res = handler.handle_request().unwrap();
-@@ -440,7 +480,7 @@ mod tests {
-             panic!("failed to duplicated tx fd!");
-         }
-         let stream = unsafe { UnixStream::from_raw_fd(fd) };
--        let fs_cache = SlaveFsCacheReq::from_stream(stream);
-+        let fs_cache = Slave::from_stream(stream);
- 
-         std::thread::spawn(move || {
-             let res = handler.handle_request().unwrap();
-diff --git a/src/vhost_user/message.rs b/src/vhost_user/message.rs
-index 6ccf926..adb485b 100644
---- a/src/vhost_user/message.rs
-+++ b/src/vhost_user/message.rs
-@@ -139,8 +139,10 @@ pub enum MasterReq {
+diff --git a/crates/vhost/src/vhost_user/message.rs b/crates/vhost/src/vhost_user/message.rs
+index b2882bc..46b73ff 100644
+--- a/crates/vhost/src/vhost_user/message.rs
++++ b/crates/vhost/src/vhost_user/message.rs
+@@ -140,8 +140,10 @@ pub enum MasterReq {
      /// Query the backend for its device status as defined in the VIRTIO
      /// specification.
      GET_STATUS = 40,
@@ -256,7 +241,7 @@ index 6ccf926..adb485b 100644
  }
  
  impl From<MasterReq> for u32 {
-@@ -171,16 +173,20 @@ pub enum SlaveReq {
+@@ -172,16 +174,20 @@ pub enum SlaveReq {
      VRING_CALL = 4,
      /// Indicate that an error occurred on the specific vring.
      VRING_ERR = 5,
@@ -282,25 +267,7 @@ index 6ccf926..adb485b 100644
  }
  
  impl From<SlaveReq> for u32 {
-@@ -817,7 +823,7 @@ pub const VHOST_USER_FS_SLAVE_ENTRIES: usize = 8;
- 
- /// Slave request message to update the MMIO window.
- #[repr(packed)]
--#[derive(Default)]
-+#[derive(Clone, Copy, Default)]
- pub struct VhostUserFSSlaveMsg {
-     /// File offset.
-     pub fd_offset: [u64; VHOST_USER_FS_SLAVE_ENTRIES],
-@@ -828,6 +834,8 @@ pub struct VhostUserFSSlaveMsg {
-     /// Flags for the mmap operation
-     pub flags: [VhostUserFSSlaveMsgFlags; VHOST_USER_FS_SLAVE_ENTRIES],
- }
-+// Safe because it only has data and has no implicit padding.
-+unsafe impl ByteValued for VhostUserFSSlaveMsg {}
- 
- impl VhostUserMsgValidator for VhostUserFSSlaveMsg {
-     fn is_valid(&self) -> bool {
-@@ -843,6 +851,99 @@ impl VhostUserMsgValidator for VhostUserFSSlaveMsg {
+@@ -862,6 +868,99 @@ impl VhostUserMsgValidator for VhostUserFSSlaveMsg {
      }
  }
  
@@ -400,7 +367,7 @@ index 6ccf926..adb485b 100644
  /// Inflight I/O descriptor state for split virtqueues
  #[repr(packed)]
  #[derive(Clone, Copy, Default)]
-@@ -974,6 +1075,31 @@ impl QueueRegionPacked {
+@@ -993,6 +1092,31 @@ impl QueueRegionPacked {
      }
  }
  
@@ -432,69 +399,13 @@ index 6ccf926..adb485b 100644
  #[cfg(test)]
  mod tests {
      use super::*;
-diff --git a/src/vhost_user/mod.rs b/src/vhost_user/mod.rs
-index ff583b9..18a4bf2 100644
---- a/src/vhost_user/mod.rs
-+++ b/src/vhost_user/mod.rs
-@@ -51,7 +51,7 @@ pub use self::slave_req_handler::{
- #[cfg(feature = "vhost-user-slave")]
- mod slave_fs_cache;
- #[cfg(feature = "vhost-user-slave")]
--pub use self::slave_fs_cache::SlaveFsCacheReq;
-+pub use self::slave_fs_cache::Slave;
- 
- /// Errors for vhost-user operations
- #[derive(Debug)]
-diff --git a/src/vhost_user/slave_fs_cache.rs b/src/vhost_user/slave_fs_cache.rs
-index e9ad7cf..6811f1c 100644
---- a/src/vhost_user/slave_fs_cache.rs
-+++ b/src/vhost_user/slave_fs_cache.rs
-@@ -7,11 +7,13 @@ use std::os::unix::io::{AsRawFd, RawFd};
- use std::os::unix::net::UnixStream;
- use std::sync::{Arc, Mutex, MutexGuard};
- 
-+use vm_memory::ByteValued;
-+
- use super::connection::Endpoint;
- use super::message::*;
- use super::{Error, HandlerResult, Result, VhostUserMasterReqHandler};
- 
--struct SlaveFsCacheReqInternal {
-+struct SlaveInternal {
-     sock: Endpoint<SlaveReq>,
- 
-     // Protocol feature VHOST_USER_PROTOCOL_F_REPLY_ACK has been negotiated.
-@@ -21,7 +23,7 @@ struct SlaveFsCacheReqInternal {
-     error: Option<i32>,
- }
- 
--impl SlaveFsCacheReqInternal {
-+impl SlaveInternal {
-     fn check_state(&self) -> Result<u64> {
-         match self.error {
-             Some(e) => Err(Error::SocketBroken(std::io::Error::from_raw_os_error(e))),
-@@ -29,27 +31,30 @@ impl SlaveFsCacheReqInternal {
+diff --git a/crates/vhost/src/vhost_user/slave_req.rs b/crates/vhost/src/vhost_user/slave_req.rs
+index ade1e91..b7ecd20 100644
+--- a/crates/vhost/src/vhost_user/slave_req.rs
++++ b/crates/vhost/src/vhost_user/slave_req.rs
+@@ -46,12 +46,16 @@ impl SlaveInternal {
          }
-     }
- 
--    fn send_message(
-+    fn send_message<T: ByteValued>(
-         &mut self,
-         request: SlaveReq,
--        fs: &VhostUserFSSlaveMsg,
-+        msg: &T,
-         fds: Option<&[RawFd]>,
-     ) -> Result<u64> {
-         self.check_state()?;
- 
--        let len = mem::size_of::<VhostUserFSSlaveMsg>();
-+        let len = mem::size_of::<T>();
-         let mut hdr = VhostUserMsgHeader::new(request, 0, len as u32);
-         if self.reply_ack_negotiated {
-             hdr.set_need_reply(true);
-         }
--        self.sock.send_message(&hdr, fs, fds)?;
-+        self.sock.send_message(&hdr, msg, fds)?;
+         self.sock.send_message(&hdr, body, fds)?;
  
 -        self.wait_for_ack(&hdr)
 +        self.wait_for_reply(&hdr)
@@ -504,72 +415,18 @@ index e9ad7cf..6811f1c 100644
 +    fn wait_for_reply(&mut self, hdr: &VhostUserMsgHeader<SlaveReq>) -> Result<u64> {
          self.check_state()?;
 -        if !self.reply_ack_negotiated {
-+        if hdr.get_code() != SlaveReq::SHMEM_MAP
-+            && hdr.get_code() != SlaveReq::SHMEM_UNMAP
-+            && !self.reply_ack_negotiated
++        if !matches!(
++            hdr.get_code(),
++            Ok(SlaveReq::SHMEM_MAP | SlaveReq::SHMEM_UNMAP)
++        ) && !self.reply_ack_negotiated
 +        {
              return Ok(0);
          }
  
-@@ -68,22 +73,22 @@ impl SlaveFsCacheReqInternal {
- /// Request proxy to send vhost-user-fs slave requests to the master through the slave
- /// communication channel.
- ///
--/// The [SlaveFsCacheReq] acts as a message proxy to forward vhost-user-fs slave requests to the
-+/// The [Slave] acts as a message proxy to forward vhost-user-fs slave requests to the
- /// master through the vhost-user slave communication channel. The forwarded messages will be
- /// handled by the [MasterReqHandler] server.
- ///
--/// [SlaveFsCacheReq]: struct.SlaveFsCacheReq.html
-+/// [Slave]: struct.Slave.html
- /// [MasterReqHandler]: struct.MasterReqHandler.html
- #[derive(Clone)]
--pub struct SlaveFsCacheReq {
-+pub struct Slave {
-     // underlying Unix domain socket for communication
--    node: Arc<Mutex<SlaveFsCacheReqInternal>>,
-+    node: Arc<Mutex<SlaveInternal>>,
+@@ -129,6 +133,16 @@ impl Slave {
  }
  
--impl SlaveFsCacheReq {
-+impl Slave {
-     fn new(ep: Endpoint<SlaveReq>) -> Self {
--        SlaveFsCacheReq {
--            node: Arc::new(Mutex::new(SlaveFsCacheReqInternal {
-+        Slave {
-+            node: Arc::new(Mutex::new(SlaveInternal {
-                 sock: ep,
-                 reply_ack_negotiated: false,
-                 error: None,
-@@ -91,18 +96,18 @@ impl SlaveFsCacheReq {
-         }
-     }
- 
--    fn node(&self) -> MutexGuard<SlaveFsCacheReqInternal> {
-+    fn node(&self) -> MutexGuard<SlaveInternal> {
-         self.node.lock().unwrap()
-     }
- 
--    fn send_message(
-+    fn send_message<T: ByteValued>(
-         &self,
-         request: SlaveReq,
--        fs: &VhostUserFSSlaveMsg,
-+        msg: &T,
-         fds: Option<&[RawFd]>,
-     ) -> io::Result<u64> {
-         self.node()
--            .send_message(request, fs, fds)
-+            .send_message(request, msg, fds)
-             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{}", e)))
-     }
- 
-@@ -126,7 +131,17 @@ impl SlaveFsCacheReq {
-     }
- }
- 
--impl VhostUserMasterReqHandler for SlaveFsCacheReq {
-+impl VhostUserMasterReqHandler for Slave {
+ impl VhostUserMasterReqHandler for Slave {
 +    /// Handle shared memory region mapping requests.
 +    fn shmem_map(&self, req: &VhostUserShmemMapMsg, fd: &dyn AsRawFd) -> HandlerResult<u64> {
 +        self.send_message(SlaveReq::SHMEM_MAP, req, Some(&[fd.as_raw_fd()]))
@@ -583,58 +440,11 @@ index e9ad7cf..6811f1c 100644
      /// Forward vhost-user-fs map file requests to the slave.
      fn fs_slave_map(&self, fs: &VhostUserFSSlaveMsg, fd: &dyn AsRawFd) -> HandlerResult<u64> {
          self.send_message(SlaveReq::FS_MAP, fs, Some(&[fd.as_raw_fd()]))
-@@ -147,7 +162,7 @@ mod tests {
-     #[test]
-     fn test_slave_fs_cache_req_set_failed() {
-         let (p1, _p2) = UnixStream::pair().unwrap();
--        let fs_cache = SlaveFsCacheReq::from_stream(p1);
-+        let fs_cache = Slave::from_stream(p1);
- 
-         assert!(fs_cache.node().error.is_none());
-         fs_cache.set_failed(libc::EAGAIN);
-@@ -157,7 +172,7 @@ mod tests {
-     #[test]
-     fn test_slave_fs_cache_send_failure() {
-         let (p1, p2) = UnixStream::pair().unwrap();
--        let fs_cache = SlaveFsCacheReq::from_stream(p1);
-+        let fs_cache = Slave::from_stream(p1);
- 
-         fs_cache.set_failed(libc::ECONNRESET);
-         fs_cache
-@@ -172,7 +187,7 @@ mod tests {
-     #[test]
-     fn test_slave_fs_cache_recv_negative() {
-         let (p1, p2) = UnixStream::pair().unwrap();
--        let fs_cache = SlaveFsCacheReq::from_stream(p1);
-+        let fs_cache = Slave::from_stream(p1);
-         let mut master = Endpoint::<SlaveReq>::from_stream(p2);
- 
-         let len = mem::size_of::<VhostUserFSSlaveMsg>();
-diff --git a/src/vhost_user/slave_req_handler.rs b/src/vhost_user/slave_req_handler.rs
-index b6f01de..f729e9d 100644
---- a/src/vhost_user/slave_req_handler.rs
-+++ b/src/vhost_user/slave_req_handler.rs
-@@ -8,9 +8,11 @@ use std::os::unix::net::UnixStream;
- use std::slice;
- use std::sync::{Arc, Mutex};
- 
-+use vm_memory::ByteValued;
-+
- use super::connection::Endpoint;
- use super::message::*;
--use super::slave_fs_cache::SlaveFsCacheReq;
-+use super::slave_fs_cache::Slave;
- use super::{take_single_file, Error, Result};
- 
- /// Services provided to the master by the slave with interior mutability.
-@@ -62,12 +64,13 @@ pub trait VhostUserSlaveReqHandler {
-     fn set_vring_enable(&self, index: u32, enable: bool) -> Result<()>;
-     fn get_config(&self, offset: u32, size: u32, flags: VhostUserConfigFlags) -> Result<Vec<u8>>;
-     fn set_config(&self, offset: u32, buf: &[u8], flags: VhostUserConfigFlags) -> Result<()>;
--    fn set_slave_req_fd(&self, _vu_req: SlaveFsCacheReq) {}
-+    fn set_slave_req_fd(&self, _vu_req: Slave) {}
-     fn get_inflight_fd(&self, inflight: &VhostUserInflight) -> Result<(VhostUserInflight, File)>;
-     fn set_inflight_fd(&self, inflight: &VhostUserInflight, file: File) -> Result<()>;
+diff --git a/crates/vhost/src/vhost_user/slave_req_handler.rs b/crates/vhost/src/vhost_user/slave_req_handler.rs
+index 69df122..6a17be6 100644
+--- a/crates/vhost/src/vhost_user/slave_req_handler.rs
++++ b/crates/vhost/src/vhost_user/slave_req_handler.rs
+@@ -70,6 +70,7 @@ pub trait VhostUserSlaveReqHandler {
      fn get_max_mem_slots(&self) -> Result<u64>;
      fn add_mem_region(&self, region: &VhostUserSingleMemoryRegion, fd: File) -> Result<()>;
      fn remove_mem_region(&self, region: &VhostUserSingleMemoryRegion) -> Result<()>;
@@ -642,16 +452,7 @@ index b6f01de..f729e9d 100644
  }
  
  /// Services provided to the master by the slave without interior mutability.
-@@ -107,7 +110,7 @@ pub trait VhostUserSlaveReqHandlerMut {
-         flags: VhostUserConfigFlags,
-     ) -> Result<Vec<u8>>;
-     fn set_config(&mut self, offset: u32, buf: &[u8], flags: VhostUserConfigFlags) -> Result<()>;
--    fn set_slave_req_fd(&mut self, _vu_req: SlaveFsCacheReq) {}
-+    fn set_slave_req_fd(&mut self, _vu_req: Slave) {}
-     fn get_inflight_fd(
-         &mut self,
-         inflight: &VhostUserInflight,
-@@ -116,6 +119,7 @@ pub trait VhostUserSlaveReqHandlerMut {
+@@ -118,6 +119,7 @@ pub trait VhostUserSlaveReqHandlerMut {
      fn get_max_mem_slots(&mut self) -> Result<u64>;
      fn add_mem_region(&mut self, region: &VhostUserSingleMemoryRegion, fd: File) -> Result<()>;
      fn remove_mem_region(&mut self, region: &VhostUserSingleMemoryRegion) -> Result<()>;
@@ -659,16 +460,7 @@ index b6f01de..f729e9d 100644
  }
  
  impl<T: VhostUserSlaveReqHandlerMut> VhostUserSlaveReqHandler for Mutex<T> {
-@@ -201,7 +205,7 @@ impl<T: VhostUserSlaveReqHandlerMut> VhostUserSlaveReqHandler for Mutex<T> {
-         self.lock().unwrap().set_config(offset, buf, flags)
-     }
- 
--    fn set_slave_req_fd(&self, vu_req: SlaveFsCacheReq) {
-+    fn set_slave_req_fd(&self, vu_req: Slave) {
-         self.lock().unwrap().set_slave_req_fd(vu_req)
-     }
- 
-@@ -224,6 +228,10 @@ impl<T: VhostUserSlaveReqHandlerMut> VhostUserSlaveReqHandler for Mutex<T> {
+@@ -226,6 +228,10 @@ impl<T: VhostUserSlaveReqHandlerMut> VhostUserSlaveReqHandler for Mutex<T> {
      fn remove_mem_region(&self, region: &VhostUserSingleMemoryRegion) -> Result<()> {
          self.lock().unwrap().remove_mem_region(region)
      }
@@ -679,11 +471,11 @@ index b6f01de..f729e9d 100644
  }
  
  /// Server to handle service requests from masters from the master communication channel.
-@@ -509,6 +517,15 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
+@@ -511,6 +517,15 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
                  let res = self.backend.remove_mem_region(&msg);
                  self.send_ack_message(&hdr, res)?;
              }
-+            MasterReq::GET_SHARED_MEMORY_REGIONS => {
++            Ok(MasterReq::GET_SHARED_MEMORY_REGIONS) => {
 +                let regions = self.backend.get_shared_memory_regions()?;
 +                let mut buf = Vec::new();
 +                let msg = VhostUserU64::new(regions.len() as u64);
@@ -695,15 +487,6 @@ index b6f01de..f729e9d 100644
              _ => {
                  return Err(Error::InvalidMessage);
              }
-@@ -622,7 +639,7 @@ impl<S: VhostUserSlaveReqHandler> SlaveReqHandler<S> {
-     fn set_slave_req_fd(&mut self, files: Option<Vec<File>>) -> Result<()> {
-         let file = take_single_file(files).ok_or(Error::InvalidMessage)?;
-         let sock = unsafe { UnixStream::from_raw_fd(file.into_raw_fd()) };
--        let vu_req = SlaveFsCacheReq::from_stream(sock);
-+        let vu_req = Slave::from_stream(sock);
-         self.backend.set_slave_req_fd(vu_req);
-         Ok(())
-     }
 -- 
-2.37.1
+2.41.0
 

--- a/pkgs/spectrum-os/cloud-hypervisor/vhost/0002-devices-vhost-user-add-protocol-flag-for-shmem.patch
+++ b/pkgs/spectrum-os/cloud-hypervisor/vhost/0002-devices-vhost-user-add-protocol-flag-for-shmem.patch
@@ -1,4 +1,4 @@
-From ee17b58f30e65a37a0526a4df60f9810fa19b138 Mon Sep 17 00:00:00 2001
+From 708d7f885e0d81ef912c9baf073fd61ba919c213 Mon Sep 17 00:00:00 2001
 From: David Stevens <stevensd@chromium.org>
 Date: Thu, 13 Oct 2022 10:37:47 +0900
 Subject: [PATCH 2/2] devices: vhost-user: add protocol flag for shmem
@@ -17,14 +17,14 @@ Commit-Queue: David Stevens <stevensd@chromium.org>
 (cherry-picked from commit 60aa43629ae9be2cc3df37c648ab7e0e5ff2172c)
 Signed-off-by: Alyssa Ross <hi@alyssa.is>
 ---
- src/vhost_user/master.rs  | 5 +++++
- src/vhost_user/message.rs | 2 ++
+ crates/vhost/src/vhost_user/master.rs  | 5 +++++
+ crates/vhost/src/vhost_user/message.rs | 2 ++
  2 files changed, 7 insertions(+)
 
-diff --git a/src/vhost_user/master.rs b/src/vhost_user/master.rs
-index deab6a7..2bbf8d6 100644
---- a/src/vhost_user/master.rs
-+++ b/src/vhost_user/master.rs
+diff --git a/crates/vhost/src/vhost_user/master.rs b/crates/vhost/src/vhost_user/master.rs
+index 60bb551..ac1520f 100644
+--- a/crates/vhost/src/vhost_user/master.rs
++++ b/crates/vhost/src/vhost_user/master.rs
 @@ -357,6 +357,11 @@ impl VhostUserMaster for Master {
      fn set_protocol_features(&mut self, features: VhostUserProtocolFeatures) -> Result<()> {
          let mut node = self.node();
@@ -37,11 +37,11 @@ index deab6a7..2bbf8d6 100644
          let val = VhostUserU64::new(features.bits());
          let hdr = node.send_request_with_body(MasterReq::SET_PROTOCOL_FEATURES, &val, None)?;
          // Don't wait for ACK here because the protocol feature negotiation process hasn't been
-diff --git a/src/vhost_user/message.rs b/src/vhost_user/message.rs
-index adb485b..09362fb 100644
---- a/src/vhost_user/message.rs
-+++ b/src/vhost_user/message.rs
-@@ -417,6 +417,8 @@ bitflags! {
+diff --git a/crates/vhost/src/vhost_user/message.rs b/crates/vhost/src/vhost_user/message.rs
+index 46b73ff..9d8c121 100644
+--- a/crates/vhost/src/vhost_user/message.rs
++++ b/crates/vhost/src/vhost_user/message.rs
+@@ -426,6 +426,8 @@ bitflags! {
          const CONFIGURE_MEM_SLOTS = 0x0000_8000;
          /// Support reporting status.
          const STATUS = 0x0001_0000;
@@ -51,5 +51,5 @@ index adb485b..09362fb 100644
  }
  
 -- 
-2.37.1
+2.41.0
 


### PR DESCRIPTION
Hello,

This PR:

* Updates the vendored version of cloud-hypervisor from upstream (identical in nixpkgs and spectrums nixpkgs atm)
* ~Removes rust-hypervisor-firmware because it's [currently broken](https://github.com/NixOS/nixpkgs/issues/256957) in nixpkgs and I don't think we need it, as cloud-hypervisor can boot kernel + initrds directly and we don't seem to depend on bootloaders?~
* ~Maybe controversal: rename cloud-hypervisor-graphics to just cloud-hypervisor and use the same build for graphical and non-graphical hosts alike. Happy to remove this or make it opt-in if needed, see commit msg for justification.~
