### PR TITLE
Remove dependency on linux-dev

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -39,7 +39,7 @@ let
             then "pci"
             else "device";
   kernelPath = {
-    x86_64-linux = "${kernel.dev}/vmlinux";
+    x86_64-linux = "${kernel.out}/bzImage";
     aarch64-linux = "${kernel.out}/${pkgs.stdenv.hostPlatform.linux-kernel.target}";
   }.${system};
 


### PR DESCRIPTION
This dependency is not necessary, since qemu knows how to boot a bzImage directly.