### PR TITLE
Update faq.md systemd-tmpfiles

### DIFF
--- a/doc/src/faq.md
+++ b/doc/src/faq.md
@@ -63,7 +63,7 @@ systemd.tmpfiles.rules = map (vmHost:
     machineId = self.lib.addresses.machineId.${vmHost};
   in
     # creates a symlink of each MicroVM's journal under the host's /var/log/journal
-    "L+ /var/log/journal/${machineId} - - - /var/lib/microvms/${vmHost}/journal/${machineId}"
+    "L+ /var/log/journal/${machineId} - - - - /var/lib/microvms/${vmHost}/journal/${machineId}"
 ) (builtins.attrNames self.lib.addresses.machineId);
 ```
 


### PR DESCRIPTION
systemd-tmpfiles config has [7 columns](https://www.man7.org/linux/man-pages/man5/tmpfiles.d.5.html). This PR improves the faq example and avoid the following error:

`/etc/tmpfiles.d/00-nixos.conf:4: Invalid age '/var/lib/microvms/<vmname>/journal/<machineId>'.`

EDIT:

Thank you very much for your work on microvm.nix 🙏