### PR TITLE
nixos-modules: add closure size + startup time optimization

### DIFF
--- a/nixos-modules/microvm/default.nix
+++ b/nixos-modules/microvm/default.nix
@@ -16,6 +16,7 @@ in
     ./system.nix
     ./mounts.nix
     ./graphics.nix
+    ./optimization.nix
   ];
 
   config = {

--- a/nixos-modules/microvm/optimization.nix
+++ b/nixos-modules/microvm/optimization.nix
@@ -1,0 +1,43 @@
+# Closure size and startup time optimization for disposable use-cases
+{ config, lib, pkgs, ... }:
+let cfg = config.microvm;
+in
+{
+  options.microvm.optimize = {
+    enable = lib.mkOption {
+      description = lib.mdDoc ''
+        Enables some optimizations to closure size and startup time:
+          - disables X libraries for non-graphical VMs
+          - defaults documentation to off
+          - defaults to using systemd in initrd
+          - builds qemu without graphics or sound for non-graphical qemu VMs
+
+        This takes a few hundred MB off the closure size, including qemu,
+        allowing for putting microvms inside Docker containers.
+
+        May cause more build time by e.g. rebuilding qemu.
+      '';
+
+      type = lib.types.bool;
+      default = true;
+    };
+  };
+
+  config = lib.mkIf (cfg.guest.enable && cfg.optimize.enable) {
+    # Avoids X deps in closure due to dbus dependencies
+    environment.noXlibs = lib.mkIf (!cfg.graphics.enable) true;
+
+    # The docs are pretty chonky
+    documentation.enable = lib.mkDefault false;
+
+    # Use systemd initrd for startup speed
+    boot.initrd.systemd.enable = lib.mkDefault true;
+
+    # networkd is used due to some strange startup time issues with nixos's
+    # homegrown dhcp implementation
+    networking.useNetworkd = lib.mkDefault true;
+    # Due to a bug in systemd-networkd: https://github.com/systemd/systemd/issues/29388
+    # we cannot use systemd-networkd-wait-online.
+    systemd.network.wait-online.enable = false;
+  };
+}


### PR DESCRIPTION
This is based on my work on MapleCTF to run microvm.nix inside a docker
container (incidentally, an awesome microvm.nix use case) and have the
size not cause substantial issues.

Overall this saves about 700MB of closure size of a naive no-op VM
configuration at practically the sole cost of eating a qemu compile.

```
co/microvm.nix » nix path-info -sSh ./result1
/nix/store/ligbkxkl1hnz2pvj8d9dfic991zfc0s0-microvm-qemu-nixos     1.7K  756.3M

co/microvm.nix » nix path-info -sSh ./result-without
/nix/store/h218db586pc627ai96j5cq2gssbvaxk8-microvm-qemu-nixos     1.7K    1.4G
```

Without:
```
[root@nixos:~]# systemd-analyze time
Startup finished in 1.402s (kernel) + 8.830s (userspace) = 10.233s
multi-user.target reached after 8.830s in userspace.
```

With:
```
[root@nixos:~]# systemd-analyze time
Startup finished in 295ms (kernel) + 2.066s (initrd) + 2.471s (userspace) = 4.834s
multi-user.target reached after 2.466s in userspace.
```

This looks impressive, and perhaps it is, but there is a lot of speed to
still get out. The dominant factors in each system startup are:

Old:
- dhcpcd.service (7.706s)
- firewall.service (917ms)
- sshd.service (518ms)

New:

This group (in total, 3.1s ish in initrd; I have no idea why they are
this bad!):

- sys-devices-platform-serial8250-tty-ttyS1.device (3.087s)
- dev-ttyS1.device (3.087s)
- sys-devices-platform-serial8250-tty-ttyS2.device (3.085s)
- dev-ttyS2.device (3.085s) dev-ttyS0.device (3.084s)
- sys-devices-pnp0-00:02-tty-ttyS0.device (3.084s)
- sys-devices-platform-serial8250-tty-ttyS3.device (3.082s)
- dev-ttyS3.device (3.082s)
- dev-disk-by\x2dpath-pci\x2d0000:00:02.0.device (3.181s)
- sys-devices-pci0000:00-0000:00:02.0-virtio1-block-vda.device (3.181s)
- dev-disk-by\x2duuid-0d9f5dc5\x2d0d09\x2d4a74\x2d88a5\x2da0a5be825cc5.device (3.181s)
- dev-vda.device (3.181s)
- dev-disk-by\x2ddiskseq-1.device (3.180s)
- dev-disk-by\x2dpath-virtio\x2dpci\x2d0000:00:02.0.device (3.180s)
- systemd-fsck@dev-vda.service (12ms)
- sys-module-fuse.device (2.968s)

Then:
- systemd-udev-trigger.service (261ms)
- firewall.service (735ms) [!!!!!]
- systemd-networkd.service (273ms)
- sshd.service (511ms)

TL;DR: overall a huge improvement but it could have another 50% shaved
off, and I really have no idea why all that hardware init takes 3
seconds!