### PR TITLE
crosvm: sync gpu params with cloud-hypervisor

### DIFF
--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -31,7 +31,14 @@ let
     aarch64-linux = "${kernel.out}/${pkgs.stdenv.hostPlatform.linux-kernel.target}";
   }.${system};
 
+  gpuParams = {
+    context-types = "virgl:virgl2:cross-domain";
+    egl = true;
+    vulkan = true;
+  };
+
 in {
+
   preStart = ''
     rm -f ${socket}
     ${microvmConfig.preStart}
@@ -42,8 +49,8 @@ in {
     rm -f ${graphics.socket}
     ${pkgs.crosvm}/bin/crosvm device gpu \
       --socket ${graphics.socket} \
-      --wayland-sock $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY \
-      --params '{"context-types":"virgl:virgl2:cross-domain"}' \
+      --wayland-sock $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY\
+      --params '${builtins.toJSON gpuParams}' \
       &
     while ! [ -S ${graphics.socket} ]; do
       sleep .1


### PR DESCRIPTION
Note that "hidden = true" for the display doesn't work as intended for me, needed to patch crosvm to actually get rid of the display showing tty1. But that's true for cloud-hypervisor as well.