### PR TITLE
cloud-hypervisor: resolve issue #152 using waitpid

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -151,8 +151,7 @@ in {
 
         api -X PUT http://localhost/api/v1/vm.power-button
 
-        # wait for exit
-        ${pkgs.socat}/bin/socat STDOUT UNIX:${socket},shut-none
+        ${pkgs.util-linux}/bin/waitpid $MAINPID
       ''
     else throw "Cannot shutdown without socket";
 


### PR DESCRIPTION
The systemd unit ExecStop script for cloud-hypervisor used to wait for machine termination by detecting the closing of the cloud-hypervisor API socket. However, it seems that this socket is actually closed before the machine is safely shut down.

Therefore, this patch replaces the listen on the socket with a waitpid on the main PID, which is the cloud-hypervisor process. This process only terminates after the machine has properly shut down.

More information and experiment results are in #152 