### PR TITLE
Make Kernel Samepage Merging optional

### DIFF
--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -466,6 +466,6 @@ in
     '';
 
     # Enable Kernel Same-Page Merging
-    hardware.ksm.enable = true;
+    hardware.ksm.enable = lib.mkDefault true;
   };
 }


### PR DESCRIPTION
As MicroVMs work fine without KSM enabled, it should probably be optional. While KSM can improve a lot of workloads, it can harm others, and so this configuration should not conflict with a value explicitly set by the user.