### PR TITLE
Fix spaces in virtiofs source

### DIFF
--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -388,13 +388,13 @@ in
         script = ''
           for d in current/share/microvm/virtiofs/*; do
             SOCKET=$(cat $d/socket)
-            SOURCE=$(cat $d/source)
-            mkdir -p $SOURCE
+            SOURCE="$(cat $d/source)"
+            mkdir -p "$SOURCE"
 
             virtiofsd \
               --socket-path=$SOCKET \
               --socket-group=${config.users.users.microvm.group} \
-              --shared-dir $SOURCE \
+              --shared-dir "$SOURCE" \
               --rlimit-nofile ${toString serviceConfig.LimitNOFILE} \
               --thread-pool-size `nproc` \
               --posix-acl --xattr \


### PR DESCRIPTION
I wanted to mount a directory with space in the name, but that failed due to missing quotes in the `microvm-virtiofsd@` service.

```nix
microvm.shares = [{
  tag = "tv_shows";
  proto = "virtiofs";
  source = "/tank/downloads/TV Shows";
  mountPoint = "/home/ftp/TV Shows";
}];
```

With this change the mount works.