### PR TITLE
feat: allow to specify a CPU to emulate with a cross-system

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -32,24 +32,40 @@ let
     ++ lib.optional microvmConfig.optimize.enable minimizeQemuClosureSize
   );
 
-  qemu = overrideQemu pkgs.qemu_kvm;
+  qemu = overrideQemu (if pkgs.buildPlatform == pkgs.hostPlatform then
+    pkgs.buildPackages.qemu_kvm else pkgs.buildPackages.qemu_full);
 
-  inherit (microvmConfig) hostName vcpu mem balloonMem user interfaces shares socket forwardPorts devices vsock graphics storeOnDisk kernel initrdPath storeDisk;
+  inherit (microvmConfig) hostName cpu vcpu mem balloonMem user interfaces shares socket forwardPorts devices vsock graphics storeOnDisk kernel initrdPath storeDisk;
   inherit (microvmConfig.qemu) extraArgs;
 
   inherit (import ../. { nixpkgs-lib = pkgs.lib; }) withDriveLetters;
   volumes = withDriveLetters microvmConfig;
 
   arch = builtins.head (builtins.split "-" system);
+
+  cpuArgs = ["-cpu"] ++ (
+    if microvmConfig.cpu == null then
+      (
+        if system == "x86_64-linux" then
+          ["host,+x2apic"]
+        else
+          ["host"]
+      )
+    else
+      [microvmConfig.cpu]
+  );
+
+  accel = if pkgs.buildPlatform == pkgs.hostPlatform then "accel=kvm:tcg"
+    else "accel=tcg";
   # PCI required by vfio-pci for PCI passthrough
   pciInDevices = lib.any ({ bus, ... }: bus == "pci") devices;
   requirePci = shares != [] || pciInDevices;
   machine = {
     x86_64-linux =
       if requirePci
-      then "q35,accel=kvm:tcg,mem-merge=on,sata=off"
-      else "microvm,accel=kvm:tcg,pit=off,pic=off,rtc=off,mem-merge=on";
-    aarch64-linux = "virt,gic-version=max,accel=kvm:tcg";
+      then "q35,${accel},mem-merge=on,sata=off"
+      else "microvm,${accel}:tcg,pit=off,pic=off,rtc=off,mem-merge=on";
+    aarch64-linux = "virt,gic-version=max,${accel}";
   }.${system};
   devType = if requirePci
             then "pci"
@@ -91,7 +107,6 @@ in {
       "-M" machine
       "-m" (toString (mem + balloonMem))
       "-smp" (toString vcpu)
-      "-enable-kvm"
       "-nodefaults" "-no-user-config"
       # qemu just hangs after shutdown, allow to exit by rebooting
       "-no-reboot"
@@ -103,15 +118,16 @@ in {
       "-serial" "chardev:stdio"
       "-device" "virtio-rng-${devType}"
     ] ++
+    lib.optionals (pkgs.buildPlatform == pkgs.hostPlatform) [
+      "-enable-kvm"
+    ] ++
+    cpuArgs ++
     lib.optionals (system == "x86_64-linux") [
-      "-cpu" "host,+x2apic"
       "-device" "i8042"
 
       "-append" "earlyprintk=ttyS0 console=ttyS0 reboot=t panic=-1 ${toString microvmConfig.kernelParams}"
     ] ++
     lib.optionals (system == "aarch64-linux") [
-      "-cpu" "host"
-
       "-append" "console=ttyAMA0 reboot=t panic=-1 ${toString microvmConfig.kernelParams}"
     ] ++
     lib.optionals storeOnDisk [
@@ -190,8 +206,8 @@ in {
           )
         )
         "-device" "virtio-net-${devType},netdev=${id},mac=${mac}${
-          # romfile= does not work with x86_64-linux and -M microvm setting
-          lib.optionalString (requirePci || system != "x86_64-linux") ",romfile="
+          # romfile= does not work with x86_64-linux and -M microvm setting or -cpu different than host
+          lib.optionalString (requirePci || (microvmConfig.cpu == null && system != "x86_64-linux")) ",romfile="
         }${
           lib.optionalString tapMultiQueue ",mq=on,vectors=${toString (2 * vcpu + 2)}"
         }"

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -16,6 +16,14 @@ in
       '';
     };
 
+    cpu = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        What CPU to emulate, if any. If different from the host architecture, it will have a serious performance hit. Not supported by all hypervisors.
+      '';
+    };
+
     hypervisor = mkOption {
       type = types.enum self-lib.hypervisors;
       default = "qemu";


### PR DESCRIPTION
Implements: https://github.com/astro/microvm.nix/issues/127

---

By setting a module of the form:

```
modules = [
  { nixpkgs.crossSystem.config = "aarch64-unknown-linux-gnu"; }
]
```

On the `lib.nixosSystem` call, and a specific CPU on the `nixosModules.microvm` call, such as:

```
microvm = {
  cpu = "cortex-a53";
}
```

Allow a different CPU to be emulated by using qemu's Tiny Code Generator (TCG). While this will have a performance impact on the guest, it allows to experiment cross-system derivations on an emulated guest.