### PR TITLE
fix: don't set `neededForBoot = false` if not necessary

### DIFF
--- a/nixos-modules/microvm/mounts.nix
+++ b/nixos-modules/microvm/mounts.nix
@@ -99,7 +99,8 @@ lib.mkIf config.microvm.guest.enable {
         "${mountPoint}" = {
           inherit fsType;
           device = "/dev/vd${letter}";
-          neededForBoot = mountPoint == config.microvm.writableStoreOverlay;
+        } // lib.optionalAttrs (mountPoint == config.microvm.writableStoreOverlay) {
+          neededForBoot = true;
         };
       }) {} (withDriveLetters config.microvm)
   ) (
@@ -112,8 +113,8 @@ lib.mkIf config.microvm.guest.enable {
           "virtiofs" = [ "defaults" "x-systemd.after=systemd-modules-load.service" ];
           "9p" = [ "trans=virtio" "version=9p2000.L"  "msize=65536" ];
         }.${proto};
-        neededForBoot = source == "/nix/store" ||
-          mountPoint == config.microvm.writableStoreOverlay;
+      } // lib.optionalAttrs (source == "/nix/store" || mountPoint == config.microvm.writableStoreOverlay) {
+        neededForBoot = true;
       };
     }) {} config.microvm.shares
   ) ];


### PR DESCRIPTION
This PR just removes unnecessary definitions of `neededForBoot = false`, which are currently set on all normal volumes added by users. Removing these makes it possible to set `neededForBoot = true` for some of them (e.g. when using impermanence) without requiring use of `lib.mkForce true` every time.

This removes unnecessary conflict messages and makes it clear that the `neededForBoot` property is _not_ set to `false` explicitly by microvm.nix, because in reality just the `neededForBoot = true` values are those that are serve a purpose.