### PR TITLE
qemu: Fix cross-compilation

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -35,8 +35,8 @@ let
     ++ lib.optional microvmConfig.optimize.enable minimizeQemuClosureSize
   );
 
-  qemu = overrideQemu (if pkgs.buildPlatform == pkgs.hostPlatform then
-    pkgs.buildPackages.qemu_kvm else pkgs.buildPackages.qemu_full);
+  qemu = overrideQemu (if microvmConfig.cpu == null then
+    pkgs.qemu_kvm else pkgs.buildPackages.qemu_full);
 
   inherit (microvmConfig) hostName cpu vcpu mem balloonMem user interfaces shares socket forwardPorts devices vsock graphics storeOnDisk kernel initrdPath storeDisk;
   inherit (microvmConfig.qemu) extraArgs;
@@ -62,7 +62,7 @@ let
     ) ];
 
   accel =
-    if pkgs.buildPlatform == pkgs.hostPlatform
+    if microvmConfig.cpu == null
     then "accel=kvm:tcg"
     else "accel=tcg";
 
@@ -143,7 +143,7 @@ in {
       "-serial" "chardev:stdio"
       "-device" "virtio-rng-${devType}"
     ] ++
-    lib.optionals (pkgs.buildPlatform == pkgs.hostPlatform) [
+    lib.optionals (microvmConfig.cpu == null) [
       "-enable-kvm"
     ] ++
     cpuArgs ++


### PR DESCRIPTION
Use microvmConfig.cpu == null to check whether we should be doing virtualization with KVM or emulation of the CPU, instead of checking pkgs.buildPlatform == pkgs.hostPlatform. The latter kind of check causes microvm not start, if the system running microvms has been cross-compiled for example from x86_64-linux to aarch64-linux.