### PR TITLE
Add tests for qemu-tcg backend

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -9,6 +9,25 @@ let
         microvm.hypervisor = "qemu";
       } ];
     } {
+      id = "qemu-tcg";
+      modules = let
+        # Emulate a different guest system than the host one
+        guestSystem = if "${system}" == "x86_64-linux" then "aarch64-unknown-linux-gnu"
+          else "x86_64-linux";
+      in [
+        {
+          microvm = {
+            hypervisor = "qemu";
+            # Force the CPU to be something else than the current
+            # system, and thus, emulated with qemu's Tiny Code Generator
+            # (TCG)
+            cpu = if "${system}" == "x86_64-linux" then "cortex-a53"
+              else "Westmere";
+          };
+          nixpkgs.crossSystem.config = guestSystem;
+        }
+      ];
+    } {
       id = "cloud-hypervisor";
       modules = [ {
         microvm.hypervisor = "cloud-hypervisor";

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -62,6 +62,7 @@ let
         microvm.writableStoreOverlay = "/nix/.rw-store";
         microvm.volumes = [ {
           image = "nix-store-overlay.img";
+          label = "nix-store";
           mountPoint = config.microvm.writableStoreOverlay;
           size = 128;
         } ];

--- a/checks/startup-shutdown.nix
+++ b/checks/startup-shutdown.nix
@@ -15,6 +15,7 @@ let
         };
         microvm = {
           volumes = [ {
+            label = "var";
             mountPoint = "/var";
             image = "var.img";
             size = 32;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -30,21 +30,35 @@ rec {
 
   createVolumesScript = pkgs: pkgs.lib.concatMapStringsSep "\n" (
     { image
+    , label
     , size ? throw "Specify a size for volume ${image} or use autoCreate = false"
     , fsType ? defaultFsType
     , autoCreate ? true
     , ...
-    }: nixpkgs-lib.optionalString autoCreate ''
-      PATH=$PATH:${with pkgs; lib.makeBinPath [ coreutils util-linux e2fsprogs ]}
+    }: pkgs.lib.warnIf
+      (label != null && !autoCreate) "Volume is not automatically labeled unless autoCreate is true. Volume has to be labeled manually, otherwise it will not be identified"
+      (let labelOption =
+             if autoCreate then
+               (if builtins.elem fsType ["ext2" "ext3" "ext4" "xfs"] then "-L"
+                else if fsType == "vfat" then "-n"
+                else (pkgs.lib.warnIf (label != null)
+                  "Will not label volume ${label} with filesystem type ${fsType}. Open an issue on the microvm.nix project to request a fix."
+                  null))
+             else null;
+           labelArgument =
+             if (labelOption != null && label != null) then "${labelOption} '${label}'"
+             else "";
+      in (nixpkgs-lib.optionalString autoCreate ''
+      PATH=$PATH:${with pkgs.buildPackages; lib.makeBinPath [ coreutils util-linux e2fsprogs ]}
 
       if [ ! -e '${image}' ]; then
         touch '${image}'
         # Mark NOCOW
         chattr +C '${image}' || true
         fallocate -l${toString size}MiB '${image}'
-        mkfs.${fsType} '${image}'
+        mkfs.${fsType} ${pkgs.lib.optionalString (label != null) "-L '${label}'"} '${image}'
       fi
-    '');
+    ''));
 
   buildRunner = import ./runner.nix;
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -56,9 +56,9 @@ rec {
         # Mark NOCOW
         chattr +C '${image}' || true
         fallocate -l${toString size}MiB '${image}'
-        mkfs.${fsType} ${pkgs.lib.optionalString (label != null) "-L '${label}'"} '${image}'
+        mkfs.${fsType} ${labelArgument} '${image}'
       fi
-    ''));
+    '')));
 
   buildRunner = import ./runner.nix;
 

--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -19,23 +19,23 @@ let
   preStart = hypervisorConfig.preStart or microvmConfig.preStart;
   tapMultiQueue = hypervisorConfig.tapMultiQueue or false;
 
-  runScriptBin = pkgs.writeScriptBin "microvm-run" ''
-    #! ${pkgs.runtimeShell} -e
+  runScriptBin = pkgs.buildPackages.writeScriptBin "microvm-run" ''
+    #! ${pkgs.buildPackages.runtimeShell} -e
 
     ${preStart}
-    ${createVolumesScript pkgs microvmConfig.volumes}
+    ${createVolumesScript pkgs.buildPackages microvmConfig.volumes}
     ${lib.optionalString (hypervisorConfig.requiresMacvtapAsFds or false) openMacvtapFds}
 
     exec ${command}
   '';
 
-  shutdownScriptBin = pkgs.writeScriptBin "microvm-shutdown" ''
+  shutdownScriptBin = pkgs.buildPackages.writeScriptBin "microvm-shutdown" ''
     #! ${pkgs.runtimeShell} -e
 
     ${shutdownCommand}
   '';
 
-  balloonScriptBin = pkgs.writeScriptBin "microvm-balloon" ''
+  balloonScriptBin = pkgs.buildPackages.writeScriptBin "microvm-balloon" ''
     #! ${pkgs.runtimeShell} -e
 
     if [ -z "$1" ]; then
@@ -48,7 +48,7 @@ let
   '';
 in
 
-pkgs.runCommand "microvm-${microvmConfig.hypervisor}-${microvmConfig.hostName}"
+pkgs.buildPackages.runCommand "microvm-${microvmConfig.hypervisor}-${microvmConfig.hostName}"
 {
   # for `nix run`
   meta.mainProgram = "microvm-run";

--- a/nixos-modules/microvm/mounts.nix
+++ b/nixos-modules/microvm/mounts.nix
@@ -94,11 +94,16 @@ lib.mkIf config.microvm.guest.enable {
     };
   } (
     # Volumes
-    builtins.foldl' (result: { mountPoint, letter, fsType ? defaultFsType, ... }:
+    builtins.foldl' (result: { label, mountPoint, letter, fsType ? defaultFsType, ... }:
       result // lib.optionalAttrs (mountPoint != null) {
         "${mountPoint}" = {
           inherit fsType;
-          device = "/dev/vd${letter}";
+          # Prioritize identifying a device by label if provided. This
+          # minimizes the risk of misidentifying a device.
+          device = if label != null then
+            "/dev/disk/by-label/${label}"
+          else
+            "/dev/vd${letter}";
         } // lib.optionalAttrs (mountPoint == config.microvm.writableStoreOverlay) {
           neededForBoot = true;
         };

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -180,6 +180,11 @@ in
             type = str;
             description = "Path to disk image on the host";
           };
+          label = mkOption {
+            type = nullOr str;
+            default = null;
+            description = "Label of the volume, if any. Only applicable if autoCreate is true; otherwise labeling of the volume must be done manually";
+          };
           mountPoint = mkOption {
             type = nullOr path;
             description = "If and where to mount the volume inside the container";


### PR DESCRIPTION
This adds tests for the qemu-tcg backend that check that the emulated machine has the expected architecture. This check also works for the rest of hypervisors.

**However**, there is something fishy when running this test case. Please, check the first comment on this PR for the error.

If you have any idea how to tackle this issue I would be glad to update the PR. Thanks!