### PR TITLE
Change microvm.host.enable to be false by default

### DIFF
--- a/nixos-modules/host.nix
+++ b/nixos-modules/host.nix
@@ -11,7 +11,7 @@ in
   options.microvm = with lib; {
     host.enable = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = ''
         Whether to enable the microvm.nix host module.
       '';


### PR DESCRIPTION
Just importing a module shouldn't change things. 
This likely requires other changes.