### PR TITLE
fix: wait for the correct mount before attempting to create an overlayfs (closes #186)

### DIFF
--- a/nixos-modules/microvm/mounts.nix
+++ b/nixos-modules/microvm/mounts.nix
@@ -38,7 +38,7 @@ lib.mkIf config.microvm.guest.enable {
       "/nix/store" = {
         device = roStoreDisk;
         fsType = storeDiskType;
-        options = [ "x-systemd.after=systemd-modules-load.service" ];
+        options = [ "x-systemd.requires=systemd-modules-load.service" ];
         neededForBoot = true;
       };
     }
@@ -65,7 +65,7 @@ lib.mkIf config.microvm.guest.enable {
       "/nix/.ro-store" = {
         device = roStoreDisk;
         fsType = storeDiskType;
-        options = [ "x-systemd.after=systemd-modules-load.service" ];
+        options = [ "x-systemd.requires=systemd-modules-load.service" ];
         neededForBoot = true;
       };
     }
@@ -115,8 +115,8 @@ lib.mkIf config.microvm.guest.enable {
         device = tag;
         fsType = proto;
         options = {
-          "virtiofs" = [ "defaults" "x-systemd.after=systemd-modules-load.service" ];
-          "9p" = [ "trans=virtio" "version=9p2000.L"  "msize=65536" ];
+          "virtiofs" = [ "defaults" "x-systemd.requires=systemd-modules-load.service" ];
+          "9p" = [ "trans=virtio" "version=9p2000.L" "msize=65536" "x-systemd.requires=systemd-modules-load.service" ];
         }.${proto};
       } // lib.optionalAttrs (source == "/nix/store" || mountPoint == config.microvm.writableStoreOverlay) {
         neededForBoot = true;
@@ -139,7 +139,7 @@ lib.mkIf config.microvm.guest.enable {
       before = [ "initrd-fs.target" ];
       requires = [ "rw-store.service" ];
       after = [ "rw-store.service" ];
-      unitConfig.RequiresMountsFor = "${roStore}";
+      unitConfig.RequiresMountsFor = "/sysroot/${roStore}";
     } ];
     services.rw-store = {
       unitConfig = {


### PR DESCRIPTION
See #186. Also adds a requires on module loading to 9p shares which can also be affected by module load order.