### PR TITLE
qemu: add option microvm.qemu.serialConsole

### DIFF
--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -394,6 +394,14 @@ in
       description = "Extra arguments to pass to qemu.";
     };
 
+    qemu.serialConsole = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to enable the virtual serial console on qemu.
+      '';
+    };
+
     crosvm.extraArgs = mkOption {
       type = with types; listOf str;
       default = [];


### PR DESCRIPTION
For some applications like UART passthrough we want to disable the default qemu virtual serial (-serial chardev:stdio). With this flag in false we remove this virtual device and the ttyAMA0/S0 kernel console.