### PR TITLE
Set microvm hostname as process name in runner

### DIFF
--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -26,7 +26,7 @@ let
     ${createVolumesScript pkgs.buildPackages microvmConfig.volumes}
     ${lib.optionalString (hypervisorConfig.requiresMacvtapAsFds or false) openMacvtapFds}
 
-    exec ${command}
+    exec -a "microvm-${microvmConfig.hostName}" ${command}
   '';
 
   shutdownScriptBin = pkgs.buildPackages.writeScriptBin "microvm-shutdown" ''


### PR DESCRIPTION
Having multiple microvm's running on my server it's always hard to see in `top` which VM is taking up resources: all processes are named `cloud-hypervisor`. This patch renames the process `/nix/store/$hash-cloud-hypervisor` (or whatever hypervisor is used) to `microvm-$hostname` making it possible to distinguish the running VM's. I'm not sure if other people also find this desirable, if not, maybe this can be added behing a toggle flag?

PS. it only shows the microvm name in `top` if the full command line is shown (eg. pressing `c`).