### PR TITLE
qemu: dont set mq=on,vectors=N for virtio-net-device

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -250,7 +250,7 @@ in {
             (microvmConfig.cpu == null && system != "x86_64-linux")
           ) ",romfile="
         }${
-          lib.optionalString tapMultiQueue ",mq=on,vectors=${toString (2 * vcpu + 2)}"
+          lib.optionalString (tapMultiQueue && requirePci) ",mq=on,vectors=${toString (2 * vcpu + 2)}"
         }"
       ]) interfaces
     )


### PR DESCRIPTION
## Description

From latest commit off main: c5074bb6d328a6071a70dcb097f8bcd208fce80a

Setting `vcpu > 1` for qemu guests would result in the following error during guest startup:

```
  qemu-system-x86_64: -device virtio-net-device,netdev=host1, \
    mac=02:00:00:00:00:01,mq=on,vectors=6: Property \
    'virtio-net-device.vectors' not found
```

I believe this is because only `virtio-net-pci` supports `mq` and `vectors`. But its hard to tell
from the documentation that I found: https://www.linux-kvm.org/page/Multiqueue#Enable_MQ_feature

### VM configuration

My hosts microvm configuration:

```
{
  microvm.qemu = {
    serialConsole = false;
    extraArgs = [
      "-serial" "pty"
    ];
  };

  microvm = {
    vcpu = 2;
    mem = 4096;
    interfaces = [{
        type = "tap";
        id = "vm-host1";
        mac = "02:00:00:00:00:01";
      }];

    volumes = [{ image = "/persist/microvm/host1.img"; mountPoint = "/persist"; size = 2000; }];
  };
}
```
