### PR TITLE
qemu: fix crash when using sgx

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -57,7 +57,8 @@ let
       if microvmConfig.cpu != null
       then microvmConfig.cpu
       else if system == "x86_64-linux"
-      then "host,+x2apic"
+      # qemu crashes when sgx is used on microvm machines: https://gitlab.com/qemu-project/qemu/-/issues/2142
+      then "host,+x2apic,-sgx"
       else "host"
     ) ];
 


### PR DESCRIPTION
This is the bare-minimum fix to make sure the qemu runner doesn't crash on hosts with SGX available. I'm open for ideas on how to make this configurable if that's necessary.

Fixes: #212
Upstream issue: https://gitlab.com/qemu-project/qemu/-/issues/2142