### PR TITLE
runner: fixed cross-compilation

### DIFF
--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -23,7 +23,7 @@ let
     ''-a "microvm@${microvmConfig.hostName}"'';
 
   runScriptBin = pkgs.buildPackages.writeScriptBin "microvm-run" ''
-    #! ${pkgs.buildPackages.runtimeShell} -e
+    #! ${pkgs.runtimeShell} -e
 
     ${preStart}
     ${createVolumesScript pkgs.buildPackages microvmConfig.volumes}


### PR DESCRIPTION
When running in aarch64 a x86 compiled version, the result microvm-run script uses x86 bash runtimeShell. Fixed by removing the buildPackages from runtimeShell.