### PR TITLE
Forward NOTIFY_SOCKET over vsock for cloud-hypervisor

### DIFF
--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -16,6 +16,7 @@ let
   };
 
   inherit (hypervisorConfig) command canShutdown shutdownCommand;
+  supportsNotifySocket = hypervisorConfig.supportsNotifySocket or false;
   preStart = hypervisorConfig.preStart or microvmConfig.preStart;
   tapMultiQueue = hypervisorConfig.tapMultiQueue or false;
 
@@ -56,7 +57,7 @@ pkgs.buildPackages.runCommand "microvm-${microvmConfig.hypervisor}-${microvmConf
   # for `nix run`
   meta.mainProgram = "microvm-run";
   passthru = {
-    inherit canShutdown;
+    inherit canShutdown supportsNotifySocket;
     inherit (microvmConfig) hypervisor;
   };
 } ''

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -224,6 +224,7 @@ in
         # we also have to include a trigger here.
         restartTriggers = [guestConfig.system.build.toplevel];
         overrideStrategy = "asDropin";
+        serviceConfig.Type = lib.mkIf guestConfig.microvm.declaredRunner.supportsNotifySocket "notify";
       };
       "microvm-tap-interfaces@${name}" = {
         serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
@@ -435,6 +436,7 @@ in
           Group = group;
           SyslogIdentifier = "microvm@%i";
           LimitNOFILE = 1048576;
+          NotifyAccess = "all";
           LimitMEMLOCK = "infinity";
         };
       };


### PR DESCRIPTION
This will forward the systemd ready notification inside the VM so the
systemd service status reflects whether the VM has finished booting.

I had to use socat to forward the messages because the NOTIFY_SOCKET that systemd creates only accepts datagrams, but cloud-hypervisor only supports streaming unix sockets.

Fixes #205