### PR TITLE
add `formatter` flake output (`nixpkgs-fmt`)

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -3,171 +3,200 @@
 let
   variants = [
     # hypervisor
-    [ {
+    [{
       id = "qemu";
-      modules = [ {
+      modules = [{
         microvm.hypervisor = "qemu";
-      } ];
-    } {
-      id = "qemu-tcg";
-      modules = let
-        # Emulate a different guest system than the host one
-        guestSystem = if "${system}" == "x86_64-linux" then "aarch64-unknown-linux-gnu"
-          else "x86_64-linux";
-      in [
-        {
-          microvm = {
-            hypervisor = "qemu";
-            # Force the CPU to be something else than the current
-            # system, and thus, emulated with qemu's Tiny Code Generator
-            # (TCG)
-            cpu = if "${system}" == "x86_64-linux" then "cortex-a53"
-              else "Westmere";
-          };
-          nixpkgs.crossSystem.config = guestSystem;
-        }
-      ];
-    } {
-      id = "cloud-hypervisor";
-      modules = [ {
-        microvm.hypervisor = "cloud-hypervisor";
-      } ];
-    } {
-      id = "crosvm";
-      modules = [ {
-        microvm.hypervisor = "crosvm";
-      } ];
-    } {
-      id = "firecracker";
-      modules = [ {
-        microvm.hypervisor = "firecracker";
-      } ];
-    } {
-      id = "kvmtool";
-      modules = [ {
-        microvm.hypervisor = "kvmtool";
-      } ];
-    } ]
+      }];
+    }
+      {
+        id = "qemu-tcg";
+        modules =
+          let
+            # Emulate a different guest system than the host one
+            guestSystem =
+              if "${system}" == "x86_64-linux" then "aarch64-unknown-linux-gnu"
+              else "x86_64-linux";
+          in
+          [
+            {
+              microvm = {
+                hypervisor = "qemu";
+                # Force the CPU to be something else than the current
+                # system, and thus, emulated with qemu's Tiny Code Generator
+                # (TCG)
+                cpu =
+                  if "${system}" == "x86_64-linux" then "cortex-a53"
+                  else "Westmere";
+              };
+              nixpkgs.crossSystem.config = guestSystem;
+            }
+          ];
+      }
+      {
+        id = "cloud-hypervisor";
+        modules = [{
+          microvm.hypervisor = "cloud-hypervisor";
+        }];
+      }
+      {
+        id = "crosvm";
+        modules = [{
+          microvm.hypervisor = "crosvm";
+        }];
+      }
+      {
+        id = "firecracker";
+        modules = [{
+          microvm.hypervisor = "firecracker";
+        }];
+      }
+      {
+        id = "kvmtool";
+        modules = [{
+          microvm.hypervisor = "kvmtool";
+        }];
+      }]
     # ro-store
-    [ {
+    [{
       # squashfs/erofs
       id = null;
-    } {
-      # 9pfs
-      id = "9pstore";
-      modules = [ ({ config, ... }: {
-        microvm = {
-          shares = [ {
-            proto = "9p";
-            tag = "ro-store";
-            source = "/nix/store";
-            mountPoint = "/nix/.ro-store";
-          } ];
-          testing.enableTest = builtins.elem config.microvm.hypervisor [
-            # Hypervisors that support 9p
-            "qemu" "crosvm" "kvmtool"
-          ];
-        };
-      }) ];
-    } ]
+    }
+      {
+        # 9pfs
+        id = "9pstore";
+        modules = [
+          ({ config, ... }: {
+            microvm = {
+              shares = [{
+                proto = "9p";
+                tag = "ro-store";
+                source = "/nix/store";
+                mountPoint = "/nix/.ro-store";
+              }];
+              testing.enableTest = builtins.elem config.microvm.hypervisor [
+                # Hypervisors that support 9p
+                "qemu"
+                "crosvm"
+                "kvmtool"
+              ];
+            };
+          })
+        ];
+      }]
     # rw-store
-    [ {
+    [{
       # none
       id = null;
-    } {
-      # overlay volume
-      id = "overlay";
-      modules = [ ({ config, ... }: {
-        microvm.writableStoreOverlay = "/nix/.rw-store";
-        microvm.volumes = [ {
-          image = "nix-store-overlay.img";
-          label = "nix-store";
-          mountPoint = config.microvm.writableStoreOverlay;
-          size = 128;
-        } ];
-      }) ];
-    } ]
+    }
+      {
+        # overlay volume
+        id = "overlay";
+        modules = [
+          ({ config, ... }: {
+            microvm.writableStoreOverlay = "/nix/.rw-store";
+            microvm.volumes = [{
+              image = "nix-store-overlay.img";
+              label = "nix-store";
+              mountPoint = config.microvm.writableStoreOverlay;
+              size = 128;
+            }];
+          })
+        ];
+      }]
     # boot.systemd
-    [ {
+    [{
       # no
       id = null;
-      modules = [ {
+      modules = [{
         boot.initrd.systemd.enable = false;
-      } ];
-    } {
-      id = "systemd";
-      modules = [ {
-        boot.initrd.systemd.enable = true;
-      } ];
-    } ]
+      }];
+    }
+      {
+        id = "systemd";
+        modules = [{
+          boot.initrd.systemd.enable = true;
+        }];
+      }]
     # hardened profile
-    [ {
+    [{
       # no
       id = null;
-    } {
-      id = "hardened";
-      modules = [ ({ modulesPath, ... }: {
-        imports = [ "${modulesPath}/profiles/hardened.nix" ];
-      }) ];
-    } ]
+    }
+      {
+        id = "hardened";
+        modules = [
+          ({ modulesPath, ... }: {
+            imports = [ "${modulesPath}/profiles/hardened.nix" ];
+          })
+        ];
+      }]
   ];
 
   allVariants =
     let
       go = variants:
-        if variants == []
-        then []
-        else builtins.concatMap (head:
-          let
-            tail = go (builtins.tail variants);
-          in
-            if tail == []
-            then [ [ head ] ]
-            else map (t: [ head ] ++ t) tail
-        ) (builtins.head variants);
+        if variants == [ ]
+        then [ ]
+        else
+          builtins.concatMap
+            (head:
+              let
+                tail = go (builtins.tail variants);
+              in
+              if tail == [ ]
+              then [ [ head ] ]
+              else map (t: [ head ] ++ t) tail
+            )
+            (builtins.head variants);
     in
-      go variants;
+    go variants;
 
   makeTestConfigs = { modules, system, name }:
-    builtins.foldl' (result: variant:
-      let
-        configName = builtins.concatStringsSep "-" (
-          builtins.filter (s: s != null) (
-            map ({ id ? null, ... }: id) variant
-            ++
-            [ name ]
-          ));
-        nixOS = nixpkgs.lib.nixosSystem {
-          inherit system;
-          modules =
-            [ self.nixosModules.microvm
-              ({ lib, ... }: {
-              options.microvm.testing.enableTest = lib.mkOption {
-                type = lib.mkOptionType {
-                  name = "bool merged all true";
-                  merge = loc: defs:
-                    builtins.all (def: def.value) defs;
-                };
-                default = true;
-              };
-            }) ]
-            ++
-            modules
-            ++
-            builtins.concatMap ({ modules ? [], ... }: modules) variant;
-        };
-      in
+    builtins.foldl'
+      (result: variant:
+        let
+          configName = builtins.concatStringsSep "-" (
+            builtins.filter (s: s != null) (
+              map ({ id ? null, ... }: id) variant
+              ++
+              [ name ]
+            ));
+          nixOS = nixpkgs.lib.nixosSystem {
+            inherit system;
+            modules =
+              [
+                self.nixosModules.microvm
+                ({ lib, ... }: {
+                  options.microvm.testing.enableTest = lib.mkOption {
+                    type = lib.mkOptionType {
+                      name = "bool merged all true";
+                      merge = loc: defs:
+                        builtins.all (def: def.value) defs;
+                    };
+                    default = true;
+                  };
+                })
+              ]
+              ++
+              modules
+              ++
+              builtins.concatMap ({ modules ? [ ], ... }: modules) variant;
+          };
+        in
         result
         //
         nixpkgs.lib.optionalAttrs nixOS.config.microvm.testing.enableTest {
           ${configName} = nixOS;
         }
-    ) {} allVariants;
+      )
+      { }
+      allVariants;
 
-    args = {
-      inherit self nixpkgs system;
-      inherit makeTestConfigs;
-    };
+  args = {
+    inherit self nixpkgs system;
+    inherit makeTestConfigs;
+  };
 
 in
 import ./shellcheck.nix args //
@@ -175,13 +204,16 @@ import ./shellcheck.nix args //
 import ./startup-shutdown.nix args //
 import ./shutdown-command.nix args //
 
-builtins.foldl' (result: hypervisor:
-  let
-    args = {
-      inherit self nixpkgs system hypervisor;
-    };
-  in
+builtins.foldl'
+  (result: hypervisor:
+    let
+      args = {
+        inherit self nixpkgs system hypervisor;
+      };
+    in
     result //
     import ./vm.nix args //
     import ./iperf.nix args
-) {} self.lib.hypervisors
+  )
+  { }
+  self.lib.hypervisors

--- a/checks/iperf.nix
+++ b/checks/iperf.nix
@@ -2,68 +2,73 @@
 
 nixpkgs.lib.optionalAttrs (builtins.elem hypervisor self.lib.hypervisorsWithNetwork) {
   # Run a VM with to test MicroVM virtiofsd
-  "vm-${hypervisor}-iperf" = import (nixpkgs + "/nixos/tests/make-test-python.nix") ({ pkgs, ... }: {
-    name = "vm-${hypervisor}-iperf";
-    nodes.vm = {
-      imports = [ self.nixosModules.host ];
-      microvm.vms."${hypervisor}-iperf-server".flake = nixpkgs.legacyPackages.${system}.runCommand "${hypervisor}-iperf-server.flake" {
-        passthru.nixosConfigurations."${hypervisor}-iperf-server" = nixpkgs.lib.nixosSystem {
-          inherit system;
-          modules = [
-            self.nixosModules.microvm
+  "vm-${hypervisor}-iperf" = import (nixpkgs + "/nixos/tests/make-test-python.nix")
+    ({ pkgs, ... }: {
+      name = "vm-${hypervisor}-iperf";
+      nodes.vm = {
+        imports = [ self.nixosModules.host ];
+        microvm.vms."${hypervisor}-iperf-server".flake = nixpkgs.legacyPackages.${system}.runCommand "${hypervisor}-iperf-server.flake"
+          {
+            passthru.nixosConfigurations."${hypervisor}-iperf-server" = nixpkgs.lib.nixosSystem {
+              inherit system;
+              modules = [
+                self.nixosModules.microvm
+                {
+                  microvm = {
+                    inherit hypervisor;
+                    interfaces = [{
+                      type = "tap";
+                      id = "microvm";
+                      mac = "00:02:00:01:01:01";
+                    }];
+                  };
+                  networking.hostName = "${hypervisor}-microvm";
+                  networking = {
+                    interfaces.eth0 = {
+                      useDHCP = false;
+                      ipv4.addresses = [{
+                        address = "10.0.0.1";
+                        prefixLength = 24;
+                      }];
+                    };
+                    firewall.enable = false;
+                  };
+                  services.iperf3.enable = true;
+                }
+              ];
+            };
+          } "touch $out";
+        environment.systemPackages = with pkgs; [
+          #with nixpkgs.legacyPackages.${system}; [
+          iperf
+          iproute
+        ];
+        virtualisation = {
+          # larger than the defaults
+          memorySize = 2048;
+          cores = 2;
+          # 9P performance optimization that quelches a qemu warning
+          msize = 65536;
+          # # allow building packages
+          # writableStore = true;
+          # # keep the store paths built inside the VM across reboots
+          # writableStoreUseTmpfs = false;
+          qemu.options = [
+            "-cpu"
             {
-              microvm = {
-                inherit hypervisor;
-                interfaces = [ {
-                  type = "tap";
-                  id = "microvm";
-                  mac = "00:02:00:01:01:01";
-                } ];
-              };
-              networking.hostName = "${hypervisor}-microvm";
-              networking = {
-                interfaces.eth0 = {
-                  useDHCP = false;
-                  ipv4.addresses = [ {
-                    address = "10.0.0.1";
-                    prefixLength = 24;
-                  } ];
-                };
-                firewall.enable = false;
-              };
-              services.iperf3.enable = true;
-            }
+              "aarch64-linux" = "cortex-a72";
+              "x86_64-linux" = "kvm64,+svm,+vmx";
+            }.${system}
           ];
         };
-      } "touch $out";
-      environment.systemPackages = with pkgs; [ #with nixpkgs.legacyPackages.${system}; [
-        iperf iproute
-      ];
-      virtualisation = {
-        # larger than the defaults
-        memorySize = 2048;
-        cores = 2;
-        # 9P performance optimization that quelches a qemu warning
-        msize = 65536;
-        # # allow building packages
-        # writableStore = true;
-        # # keep the store paths built inside the VM across reboots
-        # writableStoreUseTmpfs = false;
-        qemu.options = [
-          "-cpu"
-          {
-            "aarch64-linux" = "cortex-a72";
-            "x86_64-linux" = "kvm64,+svm,+vmx";
-          }.${system}
-        ];
       };
-    };
-    testScript = ''
-      vm.wait_for_unit("microvm@${hypervisor}-iperf-server.service", timeout = 900)
-      vm.succeed("ip addr add 10.0.0.2/24 dev microvm")
-      result = vm.wait_until_succeeds("iperf -c 10.0.0.1", timeout = 180)
-      print(result)
-    '';
-    meta.timeout = 1800;
-  }) { inherit system; pkgs = nixpkgs.legacyPackages.${system}; };
+      testScript = ''
+        vm.wait_for_unit("microvm@${hypervisor}-iperf-server.service", timeout = 900)
+        vm.succeed("ip addr add 10.0.0.2/24 dev microvm")
+        result = vm.wait_until_succeeds("iperf -c 10.0.0.1", timeout = 180)
+        print(result)
+      '';
+      meta.timeout = 1800;
+    })
+    { inherit system; pkgs = nixpkgs.legacyPackages.${system}; };
 }

--- a/checks/shellcheck.nix
+++ b/checks/shellcheck.nix
@@ -3,11 +3,13 @@
 let
   pkgs = nixpkgs.legacyPackages.${system};
 
-in {
-  shellcheck = pkgs.runCommand "microvm-shellcheck" {
-    src = self.packages.${system}.microvm;
-    nativeBuildInputs = [ pkgs.shellcheck ];
-  } ''
+in
+{
+  shellcheck = pkgs.runCommand "microvm-shellcheck"
+    {
+      src = self.packages.${system}.microvm;
+      nativeBuildInputs = [ pkgs.shellcheck ];
+    } ''
     shellcheck $src/bin/*
     touch $out
   '';

--- a/checks/shutdown-command.nix
+++ b/checks/shutdown-command.nix
@@ -23,8 +23,10 @@ let
   };
 
 in
-builtins.mapAttrs (_: nixos:
-  pkgs.runCommandLocal "microvm-test-shutdown-command" {
+builtins.mapAttrs
+  (_: nixos:
+  pkgs.runCommandLocal "microvm-test-shutdown-command"
+  {
     nativeBuildInputs = [
       nixos.config.microvm.declaredRunner
       pkgs.p7zip
@@ -39,4 +41,5 @@ builtins.mapAttrs (_: nixos:
     echo Now shutting down
     microvm-shutdown
   ''
-) configs
+  )
+  configs

--- a/checks/startup-shutdown.nix
+++ b/checks/startup-shutdown.nix
@@ -14,12 +14,12 @@ let
           useDHCP = false;
         };
         microvm = {
-          volumes = [ {
+          volumes = [{
             image = "output.img";
             label = "output";
             mountPoint = "/output";
             size = 32;
-          } ];
+          }];
           crosvm.pivotRoot = "/build/empty";
         };
         systemd.services.poweroff-again = {
@@ -34,7 +34,8 @@ let
                 crosvm = "reboot";
                 kvmtool = "reboot";
               }.${config.microvm.hypervisor};
-            in ''
+            in
+            ''
               ${pkgs.coreutils}/bin/uname > /output/kernel-name
               ${pkgs.coreutils}/bin/uname -m > /output/machine-name
 
@@ -47,42 +48,49 @@ let
   };
 
 in
-builtins.mapAttrs (_: nixos:
-  pkgs.runCommandLocal "microvm-test-startup-shutdown" {
+builtins.mapAttrs
+  (_: nixos:
+  pkgs.runCommandLocal "microvm-test-startup-shutdown"
+  {
     nativeBuildInputs = [
       nixos.config.microvm.declaredRunner
       pkgs.p7zip
     ];
     requiredSystemFeatures = [ "kvm" ];
     meta.timeout = 120;
-  } (let
-    expectedMachineName = (crossSystem:
-      if crossSystem == null then
-        expectedMachineName { config = system; }
-      else if crossSystem.config == "aarch64-unknown-linux-gnu" then
-        "aarch64"
-      else if crossSystem.config == "x86_64-linux" then
-        "x86_64"
-      else throw "unknown machine name (${crossSystem.config})"
-    );
-  in ''
-    microvm-run
+  }
+    (
+      let
+        expectedMachineName = (crossSystem:
+          if crossSystem == null then
+            expectedMachineName { config = system; }
+          else if crossSystem.config == "aarch64-unknown-linux-gnu" then
+            "aarch64"
+          else if crossSystem.config == "x86_64-linux" then
+            "x86_64"
+          else throw "unknown machine name (${crossSystem.config})"
+        );
+      in
+      ''
+        microvm-run
 
-    7z e output.img kernel-name machine-name
+        7z e output.img kernel-name machine-name
 
-    EXPECTED_KERNEL_NAME="Linux"
-    if [ "$(cat kernel-name)" != "$EXPECTED_KERNEL_NAME" ] ; then
-      echo "Kernel does not match (got: $(cat kernel-name); expected: $EXPECTED_KERNEL_NAME)"
-      exit 1
-    fi
+        EXPECTED_KERNEL_NAME="Linux"
+        if [ "$(cat kernel-name)" != "$EXPECTED_KERNEL_NAME" ] ; then
+          echo "Kernel does not match (got: $(cat kernel-name); expected: $EXPECTED_KERNEL_NAME)"
+          exit 1
+        fi
 
-    EXPECTED_MACHINE_NAME="${expectedMachineName nixos.config.nixpkgs.crossSystem}"
-    if [ "$(cat machine-name)" != "$EXPECTED_MACHINE_NAME" ] ; then
-      echo "Machine does not match (got: $(cat machine-name); expected: $EXPECTED_MACHINE_NAME)"
-      exit 1
-    fi
+        EXPECTED_MACHINE_NAME="${expectedMachineName nixos.config.nixpkgs.crossSystem}"
+        if [ "$(cat machine-name)" != "$EXPECTED_MACHINE_NAME" ] ; then
+          echo "Machine does not match (got: $(cat machine-name); expected: $EXPECTED_MACHINE_NAME)"
+          exit 1
+        fi
 
-    mkdir $out
-    cp {kernel-name,machine-name} $out
-  '')
-) configs
+        mkdir $out
+        cp {kernel-name,machine-name} $out
+      ''
+    )
+  )
+  configs

--- a/checks/vm.nix
+++ b/checks/vm.nix
@@ -2,26 +2,28 @@
 
 {
   # Run a VM with a MicroVM
-  "vm-${hypervisor}" = import (nixpkgs + "/nixos/tests/make-test-python.nix") ({ ... }: {
-    name = "vm-${hypervisor}";
-    nodes.vm = {
-      imports = [ self.nixosModules.host ];
+  "vm-${hypervisor}" = import (nixpkgs + "/nixos/tests/make-test-python.nix")
+    ({ ... }: {
+      name = "vm-${hypervisor}";
+      nodes.vm = {
+        imports = [ self.nixosModules.host ];
 
-      virtualisation.qemu.options = [
-        "-cpu"
-        {
-          "aarch64-linux" = "cortex-a72";
-          "x86_64-linux" = "kvm64,+svm,+vmx";
-        }.${system}
-      ];
-      # Must be big enough for the store overlay volume
-      virtualisation.diskSize = 4096;
+        virtualisation.qemu.options = [
+          "-cpu"
+          {
+            "aarch64-linux" = "cortex-a72";
+            "x86_64-linux" = "kvm64,+svm,+vmx";
+          }.${system}
+        ];
+        # Must be big enough for the store overlay volume
+        virtualisation.diskSize = 4096;
 
-      microvm.vms."${system}-${hypervisor}-example".flake = self;
-    };
-    testScript = ''
-      vm.wait_for_unit("microvm@${system}-${hypervisor}-example.service", timeout = 1200)
-    '';
-    meta.timeout = 1800;
-  }) { inherit system; pkgs = nixpkgs.legacyPackages.${system}; };
+        microvm.vms."${system}-${hypervisor}-example".flake = self;
+      };
+      testScript = ''
+        vm.wait_for_unit("microvm@${system}-${hypervisor}-example.service", timeout = 1200)
+      '';
+      meta.timeout = 1800;
+    })
+    { inherit system; pkgs = nixpkgs.legacyPackages.${system}; };
 }

--- a/examples/graphics.nix
+++ b/examples/graphics.nix
@@ -1,4 +1,6 @@
-{ self, nixpkgs, system
+{ self
+, nixpkgs
+, system
 , packages ? ""
 , tapInterface ? null
 }:
@@ -32,7 +34,7 @@ nixpkgs.lib.nixosSystem {
         isNormalUser = true;
         extraGroups = [ "wheel" "video" ];
       };
-      users.groups.user = {};
+      users.groups.user = { };
       security.sudo = {
         enable = true;
         wheelNeedsPassword = false;
@@ -62,12 +64,16 @@ nixpkgs.lib.nixosSystem {
 
       environment.systemPackages = with pkgs; [
         xdg-utils # Required
-      ] ++ map (package:
-        lib.attrByPath (lib.splitString "." package) (throw "Package ${package} not found in nixpkgs") pkgs
-      ) (
-        builtins.filter (package:
-          package != ""
-        ) (lib.splitString " " packages));
+      ] ++ map
+        (package:
+          lib.attrByPath (lib.splitString "." package) (throw "Package ${package} not found in nixpkgs") pkgs
+        )
+        (
+          builtins.filter
+            (package:
+              package != ""
+            )
+            (lib.splitString " " packages));
 
       hardware.opengl.enable = true;
     })

--- a/examples/no-flake-microvm.nix
+++ b/examples/no-flake-microvm.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 
 let
   hypervisor = "cloud-hypervisor";
@@ -25,11 +25,11 @@ let
         mountPoint = "/nix/.ro-store";
       };
       writableStoreOverlay = "/nix/.rw-store";
-      volumes = [ {
+      volumes = [{
         image = "nix-store-overlay.img";
         mountPoint = config.microvm.writableStoreOverlay;
         size = 2048;
-      } ];
+      }];
       interfaces = lib.optional (builtins.elem hypervisor hypervisorsWithUserNet) {
         type = "user";
         id = "qemu";

--- a/examples/qemu-vnc.nix
+++ b/examples/qemu-vnc.nix
@@ -31,12 +31,16 @@ nixpkgs.lib.nixosSystem {
       system.stateVersion = config.system.nixos.version;
 
       microvm.qemu.extraArgs = [
-        "-vnc" ":0"
-        "-vga" "qxl"
+        "-vnc"
+        ":0"
+        "-vga"
+        "qxl"
         # needed for mounse/keyboard input via vnc
-        "-device" "virtio-keyboard"
+        "-device"
+        "virtio-keyboard"
         "-usb"
-        "-device" "usb-tablet,bus=usb-bus.0"
+        "-device"
+        "usb-tablet,bus=usb-bus.0"
       ];
 
       services.getty.autologinUser = "user";

--- a/flake-template/flake.nix
+++ b/flake-template/flake.nix
@@ -7,7 +7,8 @@
   outputs = { self, nixpkgs, microvm }:
     let
       system = "x86_64-linux";
-    in {
+    in
+    {
       packages.${system}.default = self.packages.${system}.my-microvm;
 
       packages.${system} = {
@@ -23,12 +24,12 @@
               networking.hostName = "my-microvm";
               users.users.root.password = "";
               microvm = {
-                volumes = [ {
+                volumes = [{
                   mountPoint = "/var";
                   image = "var.img";
                   size = 256;
-                } ];
-                shares = [ {
+                }];
+                shares = [{
                   # use "virtiofs" for MicroVMs that are started by systemd
                   proto = "9p";
                   tag = "ro-store";
@@ -36,7 +37,7 @@
                   # squashfs/erofs will be built for it.
                   source = "/nix/store";
                   mountPoint = "/nix/.ro-store";
-                } ];
+                }];
 
                 hypervisor = "qemu";
                 socket = "control.socket";

--- a/flake.nix
+++ b/flake.nix
@@ -137,6 +137,8 @@
             meta.timeout = 12 * 60 * 60;
           })
         ) (import ./checks { inherit self nixpkgs system; });
+
+        formatter = nixpkgs.legacyPackages.${system}.nixpkgs-fmt;
       }) // {
         lib = import ./lib { nixpkgs-lib = nixpkgs.lib; };
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -20,13 +20,15 @@ rec {
         then 1
         else 0;
     in
-    map ({ fst, snd }:
-      fst // {
-        letter = snd;
-      }
-    ) (nixpkgs-lib.zipLists volumes (
-      nixpkgs-lib.drop offset nixpkgs-lib.strings.lowerChars
-    ));
+    map
+      ({ fst, snd }:
+        fst // {
+          letter = snd;
+        }
+      )
+      (nixpkgs-lib.zipLists volumes (
+        nixpkgs-lib.drop offset nixpkgs-lib.strings.lowerChars
+      ));
 
   createVolumesScript = pkgs: pkgs.lib.concatMapStringsSep "\n" (
     { image
@@ -37,28 +39,34 @@ rec {
     , ...
     }: pkgs.lib.warnIf
       (label != null && !autoCreate) "Volume is not automatically labeled unless autoCreate is true. Volume has to be labeled manually, otherwise it will not be identified"
-      (let labelOption =
-             if autoCreate then
-               (if builtins.elem fsType ["ext2" "ext3" "ext4" "xfs"] then "-L"
-                else if fsType == "vfat" then "-n"
-                else (pkgs.lib.warnIf (label != null)
+      (
+        let
+          labelOption =
+            if autoCreate then
+              (if builtins.elem fsType [ "ext2" "ext3" "ext4" "xfs" ] then "-L"
+              else if fsType == "vfat" then "-n"
+              else
+                (pkgs.lib.warnIf (label != null)
                   "Will not label volume ${label} with filesystem type ${fsType}. Open an issue on the microvm.nix project to request a fix."
                   null))
-             else null;
-           labelArgument =
-             if (labelOption != null && label != null) then "${labelOption} '${label}'"
-             else "";
-      in (nixpkgs-lib.optionalString autoCreate ''
-      PATH=$PATH:${with pkgs.buildPackages; lib.makeBinPath [ coreutils util-linux e2fsprogs xfsprogs dosfstools ]}
+            else null;
+          labelArgument =
+            if (labelOption != null && label != null) then "${labelOption} '${label}'"
+            else "";
+        in
+        (nixpkgs-lib.optionalString autoCreate ''
+          PATH=$PATH:${with pkgs.buildPackages; lib.makeBinPath [ coreutils util-linux e2fsprogs xfsprogs dosfstools ]}
 
-      if [ ! -e '${image}' ]; then
-        touch '${image}'
-        # Mark NOCOW
-        chattr +C '${image}' || true
-        fallocate -l${toString size}MiB '${image}'
-        mkfs.${fsType} ${labelArgument} '${image}'
-      fi
-    '')));
+          if [ ! -e '${image}' ]; then
+            touch '${image}'
+            # Mark NOCOW
+            chattr +C '${image}' || true
+            fallocate -l${toString size}MiB '${image}'
+            mkfs.${fsType} ${labelArgument} '${image}'
+          fi
+        '')
+      )
+  );
 
   buildRunner = import ./runner.nix;
 

--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -31,28 +31,32 @@ let
       # Enabling simultaneous multithreading is not supported on aarch64
       smt = system != "aarch64-linux";
     };
-    drives = [ {
+    drives = [{
       drive_id = "store";
       path_on_host = storeDisk;
       is_root_device = false;
       is_read_only = true;
       io_engine = "Async";
-    } ] ++ map ({ image, ... }: {
-      drive_id = image;
-      path_on_host = image;
-      is_root_device = false;
-      is_read_only = false;
-      io_engine = "Async";
-    }) volumes;
-    network-interfaces = map ({ type, id, mac, ... }:
-      if type == "tap"
-      then {
-        iface_id = id;
-        host_dev_name = id;
-        guest_mac = mac;
-      }
-      else throw "Network interface type ${type} not implemented for Firecracker"
-    ) interfaces;
+    }] ++ map
+      ({ image, ... }: {
+        drive_id = image;
+        path_on_host = image;
+        is_root_device = false;
+        is_read_only = false;
+        io_engine = "Async";
+      })
+      volumes;
+    network-interfaces = map
+      ({ type, id, mac, ... }:
+        if type == "tap"
+        then {
+          iface_id = id;
+          host_dev_name = id;
+          guest_mac = mac;
+        }
+        else throw "Network interface type ${type} not implemented for Firecracker"
+      )
+      interfaces;
     vsock = null;
   };
 
@@ -60,23 +64,27 @@ let
     builtins.toJSON config
   );
 
-in {
+in
+{
   command =
     if user != null
     then throw "firecracker will not change user"
-    else if shares != []
+    else if shares != [ ]
     then throw "9p/virtiofs shares not implemented for Firecracker"
-    else if devices != []
+    else if devices != [ ]
     then throw "devices passthrough not implemented for Firecracker"
-    else lib.escapeShellArgs [
-      "${pkgs.firecracker}/bin/firecracker"
-      "--config-file" configFile
-      "--api-sock" (
-        if socket != null
-        then socket
-        else throw "Firecracker must be configured with an API socket (option microvm.socket)!"
-      )
-    ];
+    else
+      lib.escapeShellArgs [
+        "${pkgs.firecracker}/bin/firecracker"
+        "--config-file"
+        configFile
+        "--api-sock"
+        (
+          if socket != null
+          then socket
+          else throw "Firecracker must be configured with an API socket (option microvm.socket)!"
+        )
+      ];
 
   preStart = ''
     ${preStart}

--- a/lib/runners/kvmtool.nix
+++ b/lib/runners/kvmtool.nix
@@ -10,7 +10,8 @@ let
     vcpu mem balloonMem interfaces volumes shares devices vsock
     kernel initrdPath
     storeDisk storeOnDisk;
-in {
+in
+{
   preStart = ''
     ${preStart}
     export HOME=$PWD
@@ -19,57 +20,79 @@ in {
   command =
     if user != null
     then throw "kvmtool will not change user"
-    else builtins.concatStringsSep " " (
-      [
-        "${pkgs.kvmtool}/bin/lkvm" "run"
-        "--name" (lib.escapeShellArg hostName)
-        "-m" (toString (mem + balloonMem))
-        "-c" (toString vcpu)
-        "--console" "serial"
-        "--rng"
-        "-k" (lib.escapeShellArg "${kernel}/${pkgs.stdenv.hostPlatform.linux-kernel.target}")
-        "-i" initrdPath
-        "-p" (lib.escapeShellArg "console=ttyS0 reboot=k panic=1 ${toString microvmConfig.kernelParams}")
-      ]
-      ++
-      lib.optionals storeOnDisk [
-        "-d" (lib.escapeShellArg "${storeDisk},ro")
-      ]
-      ++
-      lib.optionals (balloonMem > 0) [ "--balloon" ]
-      ++
-      builtins.concatMap ({ image, ... }:
-        [ "-d" (lib.escapeShellArg image) ]
-      ) volumes
-      ++
-      builtins.concatMap ({ proto, source, tag, ... }:
-        if proto == "9p"
-        then [
-          "--9p" (lib.escapeShellArg "${source},${tag}")
-        ] else throw "virtiofs shares not implemented for kvmtool"
-      ) shares
-      ++
-      builtins.concatMap ({ type, id, mac, ... }:
-        if builtins.elem type [ "user" "tap" ]
-        then [
-          "-n" (lib.escapeShellArg "mode=${type},tapif=${id},guest_mac=${mac}")
+    else
+      builtins.concatStringsSep " " (
+        [
+          "${pkgs.kvmtool}/bin/lkvm"
+          "run"
+          "--name"
+          (lib.escapeShellArg hostName)
+          "-m"
+          (toString (mem + balloonMem))
+          "-c"
+          (toString vcpu)
+          "--console"
+          "serial"
+          "--rng"
+          "-k"
+          (lib.escapeShellArg "${kernel}/${pkgs.stdenv.hostPlatform.linux-kernel.target}")
+          "-i"
+          initrdPath
+          "-p"
+          (lib.escapeShellArg "console=ttyS0 reboot=k panic=1 ${toString microvmConfig.kernelParams}")
         ]
-        else if type == "macvtap"
-        then [
-          "-n" "mode=tap,tapif=/dev/tap$(< /sys/class/net/${id}/ifindex),guest_mac=${mac}"
+        ++
+        lib.optionals storeOnDisk [
+          "-d"
+          (lib.escapeShellArg "${storeDisk},ro")
         ]
-        else throw "interface type ${type} is not supported by kvmtool"
-      ) interfaces
-      ++
-      map ({ bus, path }: {
-        pci = lib.escapeShellArg "--vfio-pci=${path}";
-        usb = throw "USB passthrough is not supported on kvmtool";
-      }.${bus}) devices
-      ++
-      lib.optionals (vsock.cid != null) [
-        "--vsock" (toString vsock.cid)
-      ]
-    );
+        ++
+        lib.optionals (balloonMem > 0) [ "--balloon" ]
+        ++
+        builtins.concatMap
+          ({ image, ... }:
+            [ "-d" (lib.escapeShellArg image) ]
+          )
+          volumes
+        ++
+        builtins.concatMap
+          ({ proto, source, tag, ... }:
+            if proto == "9p"
+            then [
+              "--9p"
+              (lib.escapeShellArg "${source},${tag}")
+            ] else throw "virtiofs shares not implemented for kvmtool"
+          )
+          shares
+        ++
+        builtins.concatMap
+          ({ type, id, mac, ... }:
+            if builtins.elem type [ "user" "tap" ]
+            then [
+              "-n"
+              (lib.escapeShellArg "mode=${type},tapif=${id},guest_mac=${mac}")
+            ]
+            else if type == "macvtap"
+            then [
+              "-n"
+              "mode=tap,tapif=/dev/tap$(< /sys/class/net/${id}/ifindex),guest_mac=${mac}"
+            ]
+            else throw "interface type ${type} is not supported by kvmtool"
+          )
+          interfaces
+        ++
+        map
+          ({ bus, path }: {
+            pci = lib.escapeShellArg "--vfio-pci=${path}";
+            usb = throw "USB passthrough is not supported on kvmtool";
+          }.${bus})
+          devices
+        ++
+        lib.optionals (vsock.cid != null) [
+          "--vsock"
+          (toString vsock.cid)
+        ]
+      );
 
   # `lkvm stop` works but is not graceful.
   canShutdown = false;

--- a/lib/runners/stratovirt.nix
+++ b/lib/runners/stratovirt.nix
@@ -42,117 +42,151 @@ let
     else "device";
 
   enumerate = n: xs:
-    if xs == []
-    then []
+    if xs == [ ]
+    then [ ]
     else [
       (builtins.head xs // { index = n; })
     ] ++ (enumerate (n + 1) (builtins.tail xs));
 
   forwardPortsOptions =
-      let
-        forwardingOptions = lib.flip lib.concatMapStrings forwardPorts
-          ({ proto, from, host, guest }:
-            if from == "host"
-              then "hostfwd=${proto}:${host.address}:${toString host.port}-" +
-                   "${guest.address}:${toString guest.port},"
-              else "guestfwd=${proto}:${guest.address}:${toString guest.port}-" +
-                   "cmd:${pkgs.netcat}/bin/nc ${host.address} ${toString host.port},"
-          );
-      in
-      [ forwardingOptions ];
+    let
+      forwardingOptions = lib.flip lib.concatMapStrings forwardPorts
+        ({ proto, from, host, guest }:
+          if from == "host"
+          then "hostfwd=${proto}:${host.address}:${toString host.port}-" +
+            "${guest.address}:${toString guest.port},"
+          else "guestfwd=${proto}:${guest.address}:${toString guest.port}-" +
+            "cmd:${pkgs.netcat}/bin/nc ${host.address} ${toString host.port},"
+        );
+    in
+    [ forwardingOptions ];
 
   writeQmp = data: ''
     echo '${builtins.toJSON data}' | nc -U "${socket}"
   '';
-in {
+in
+{
   inherit tapMultiQueue;
 
   command = lib.escapeShellArgs (
     [
       "${pkgs.stratovirt}/bin/stratovirt"
-      "-name" hostName
-      "-machine" machine
-      "-m" (toString mem)
-      "-smp" (toString vcpu)
+      "-name"
+      hostName
+      "-machine"
+      machine
+      "-m"
+      (toString mem)
+      "-smp"
+      (toString vcpu)
 
-      "-kernel" "${kernel}/bzImage"
-      "-initrd" initrdPath
-      "-append" "console=${console} edd=off reboot=t panic=-1 verbose ${toString microvmConfig.kernelParams}"
+      "-kernel"
+      "${kernel}/bzImage"
+      "-initrd"
+      initrdPath
+      "-append"
+      "console=${console} edd=off reboot=t panic=-1 verbose ${toString microvmConfig.kernelParams}"
 
-      "-serial" "stdio"
-      "-object" "rng-random,id=rng,filename=/dev/random"
-      "-device" "virtio-rng-${devType 1},rng=rng,id=rng_dev"
+      "-serial"
+      "stdio"
+      "-object"
+      "rng-random,id=rng,filename=/dev/random"
+      "-device"
+      "virtio-rng-${devType 1},rng=rng,id=rng_dev"
     ] ++
     lib.optionals storeOnDisk [
-      "-drive" "id=store,format=raw,readonly=on,file=${storeDisk},if=none,aio=io_uring"
-      "-device" "virtio-blk-${devType 2},drive=store,id=blk_store"
+      "-drive"
+      "id=store,format=raw,readonly=on,file=${storeDisk},if=none,aio=io_uring"
+      "-device"
+      "virtio-blk-${devType 2},drive=store,id=blk_store"
     ] ++
     lib.optionals (socket != null) [ "-qmp" "unix:${socket},server,nowait" ] ++
-    builtins.concatMap ({ image, letter, ... }: [
-      "-drive" "id=vd${letter},format=raw,file=${image},aio=io_uring"
-      "-device" "virtio-blk-${devType 4},drive=vd${letter},id=blk_vd${letter}"
-    ]) volumes ++
-    lib.optionals (shares != []) (
-      builtins.concatMap ({ proto, index, socket, source, tag, ... }: {
-        "virtiofs" = [
-          "-chardev" "socket,id=fs${toString index},path=${socket}"
-          "-device" "vhost-user-fs-${devType (5 + index)},chardev=fs${toString index},tag=${tag}"
+    builtins.concatMap
+      ({ image, letter, ... }: [
+        "-drive"
+        "id=vd${letter},format=raw,file=${image},aio=io_uring"
+        "-device"
+        "virtio-blk-${devType 4},drive=vd${letter},id=blk_vd${letter}"
+      ])
+      volumes ++
+    lib.optionals (shares != [ ]) (
+      builtins.concatMap
+        ({ proto, index, socket, source, tag, ... }: {
+          "virtiofs" = [
+            "-chardev"
+            "socket,id=fs${toString index},path=${socket}"
+            "-device"
+            "vhost-user-fs-${devType (5 + index)},chardev=fs${toString index},tag=${tag}"
+          ];
+        }.${proto})
+        (enumerate 0 shares)
+    )
+    ++
+    lib.warnIf
+      (
+        forwardPorts != [ ] &&
+        ! builtins.any ({ type, ... }: type == "user") interfaces
+      ) "${hostName}: forwardPortsOptions only running with user network"
+      (
+        builtins.concatMap
+          ({ type, id, mac, bridge, ... }: [
+            "-netdev"
+            (
+              lib.concatStringsSep "," (
+                [
+                  (if type == "macvtap" then "tap" else "${type}")
+                  "id=${id}"
+                  "queues=${toString (lib.min 16 vcpu)}"
+                ]
+                ++ lib.optionals (type == "user" && forwardPortsOptions != [ ]) forwardPortsOptions
+                ++ lib.optionals (type == "bridge") [
+                  "br=${bridge}"
+                  "helper=/run/wrappers/bin/qemu-bridge-helper"
+                ]
+                ++ lib.optionals (type == "tap") [
+                  "ifname=${id}"
+                ]
+                ++ lib.optionals (type == "macvtap") [
+                  "fd=${toString macvtapFds.${id}}"
+                ]
+                ++ lib.optionals tapMultiQueue [
+                  "queues=${toString vcpu}"
+                ]
+              )
+            )
+            # TODO: devType (0x10 + i)
+            "-device"
+            (
+              lib.concatStringsSep "," [
+                "virtio-net-${devType 30}"
+                "id=net_${id}"
+                "netdev=${id}"
+                "mac=${mac}"
+                "mq=${if tapMultiQueue then "on" else "off"}"
+              ]
+            )
+          ])
+          interfaces
+      )
+    ++
+    builtins.concatMap
+      ({ bus, path, ... }: {
+        pci = [
+          "-device"
+          "vfio-pci,host=${path}"
         ];
-      }.${proto}) (enumerate 0 shares)
-    )
-    ++
-    lib.warnIf (
-      forwardPorts != [] &&
-      ! builtins.any ({ type, ... }: type == "user") interfaces
-    ) "${hostName}: forwardPortsOptions only running with user network" (
-      builtins.concatMap ({ type, id, mac, bridge, ... }: [
-        "-netdev" (
-          lib.concatStringsSep "," (
-            [
-              (if type == "macvtap" then "tap" else "${type}")
-              "id=${id}"
-              "queues=${toString (lib.min 16 vcpu)}"
-            ]
-            ++ lib.optionals (type == "user" && forwardPortsOptions != []) forwardPortsOptions
-            ++ lib.optionals (type == "bridge") [
-              "br=${bridge}" "helper=/run/wrappers/bin/qemu-bridge-helper"
-            ]
-            ++ lib.optionals (type == "tap") [
-              "ifname=${id}"
-            ]
-            ++ lib.optionals (type == "macvtap") [
-              "fd=${toString macvtapFds.${id}}"
-            ]
-            ++ lib.optionals tapMultiQueue [
-              "queues=${toString vcpu}"
-            ]
-          )
-        )
-        # TODO: devType (0x10 + i)
-        "-device" (
-          lib.concatStringsSep "," [
-            "virtio-net-${devType 30}"
-            "id=net_${id}"
-            "netdev=${id}"
-            "mac=${mac}"
-            "mq=${if tapMultiQueue then "on" else "off"}"
-          ]
-        )
-      ]) interfaces
-    )
-    ++
-    builtins.concatMap ({ bus, path, ... }: {
-      pci = [
-        "-device" "vfio-pci,host=${path}"
-      ];
-      usb = [
-        "-device" "usb-host,${path}"
-      ];
-    }.${bus}) devices
+        usb = [
+          "-device"
+          "usb-host,${path}"
+        ];
+      }.${bus})
+      devices
     ++
     lib.optionals (lib.hasPrefix "q35" machine) [
-      "-drive" "file=${pkgs.OVMF.fd}/FV/OVMF_CODE.fd,if=pflash,unit=0,readonly=true"
-      "-drive" "file=${pkgs.OVMF.fd}/FV/OVMF_VARS.fd,if=pflash,unit=1,readonly=true"
+      "-drive"
+      "file=${pkgs.OVMF.fd}/FV/OVMF_CODE.fd,if=pflash,unit=0,readonly=true"
+      "-drive"
+      "file=${pkgs.OVMF.fd}/FV/OVMF_VARS.fd,if=pflash,unit=1,readonly=true"
     ]
   );
 

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -37,7 +37,8 @@ in
                         networking.hostName = lib.mkDefault name;
                       };
                     };
-                  in [
+                  in
+                  [
                     extraConfig
                     ../microvm
                   ] ++ (map (x: x.value) defs);
@@ -60,7 +61,7 @@ in
 
           specialArgs = mkOption {
             type = types.attrsOf types.unspecified;
-            default = {};
+            default = { };
             description = lib.mdDoc ''
               This option is only respected when `config` is specified.
               A set of special arguments to be passed to NixOS modules.
@@ -99,7 +100,7 @@ in
           };
         };
       }));
-      default = {};
+      default = { };
       description = ''
         The MicroVMs that shall be built declaratively with the host NixOS.
       '';
@@ -115,7 +116,7 @@ in
 
     autostart = mkOption {
       type = with types; listOf str;
-      default = [];
+      default = [ ];
       description = ''
         MicroVMs to start by default.
 
@@ -125,16 +126,18 @@ in
   };
 
   config = lib.mkIf config.microvm.host.enable {
-    assertions = lib.concatMap (vmName: [
-      {
-        assertion = config.microvm.vms.${vmName}.config != null -> config.microvm.vms.${vmName}.flake == null;
-        message = "vm ${vmName}: Fully-declarative VMs cannot also set a flake!";
-      }
-      {
-        assertion = config.microvm.vms.${vmName}.config != null -> config.microvm.vms.${vmName}.updateFlake == null;
-        message = "vm ${vmName}: Fully-declarative VMs cannot set a updateFlake!";
-      }
-    ]) (builtins.attrNames config.microvm.vms);
+    assertions = lib.concatMap
+      (vmName: [
+        {
+          assertion = config.microvm.vms.${vmName}.config != null -> config.microvm.vms.${vmName}.flake == null;
+          message = "vm ${vmName}: Fully-declarative VMs cannot also set a flake!";
+        }
+        {
+          assertion = config.microvm.vms.${vmName}.config != null -> config.microvm.vms.${vmName}.updateFlake == null;
+          message = "vm ${vmName}: Fully-declarative VMs cannot set a updateFlake!";
+        }
+      ])
+      (builtins.attrNames config.microvm.vms);
 
     system.activationScripts.microvm-host = ''
       mkdir -p ${stateDir}
@@ -168,281 +171,290 @@ in
       }
     ];
 
-    systemd.services = builtins.foldl' (result: name: result // (
-      let
-        microvmConfig = config.microvm.vms.${name};
-        inherit (microvmConfig) flake updateFlake;
-        isFlake = flake != null;
-        guestConfig = if isFlake
-                      then flake.nixosConfigurations.${name}.config
-                      else microvmConfig.config.config;
-        runner = guestConfig.microvm.declaredRunner;
-      in
-    {
-      "install-microvm-${name}" = {
-        description = "Install MicroVM '${name}'";
-        before = [
-          "microvm@${name}.service"
-          "microvm-tap-interfaces@${name}.service"
-          "microvm-pci-devices@${name}.service"
-          "microvm-virtiofsd@${name}.service"
-        ];
-        partOf = [ "microvm@${name}.service" ];
-        wantedBy = [ "microvms.target" ];
-        # Only run this if the MicroVM is fully-declarative
-        # or /var/lib/microvms/$name does not exist yet.
-        unitConfig.ConditionPathExists = lib.mkIf isFlake "!${stateDir}/${name}";
-        serviceConfig.Type = "oneshot";
-        script = ''
-            mkdir -p ${stateDir}/${name}
-            cd ${stateDir}/${name}
+    systemd.services = builtins.foldl'
+      (result: name: result // (
+        let
+          microvmConfig = config.microvm.vms.${name};
+          inherit (microvmConfig) flake updateFlake;
+          isFlake = flake != null;
+          guestConfig =
+            if isFlake
+            then flake.nixosConfigurations.${name}.config
+            else microvmConfig.config.config;
+          runner = guestConfig.microvm.declaredRunner;
+        in
+        {
+          "install-microvm-${name}" = {
+            description = "Install MicroVM '${name}'";
+            before = [
+              "microvm@${name}.service"
+              "microvm-tap-interfaces@${name}.service"
+              "microvm-pci-devices@${name}.service"
+              "microvm-virtiofsd@${name}.service"
+            ];
+            partOf = [ "microvm@${name}.service" ];
+            wantedBy = [ "microvms.target" ];
+            # Only run this if the MicroVM is fully-declarative
+            # or /var/lib/microvms/$name does not exist yet.
+            unitConfig.ConditionPathExists = lib.mkIf isFlake "!${stateDir}/${name}";
+            serviceConfig.Type = "oneshot";
+            script = ''
+              mkdir -p ${stateDir}/${name}
+              cd ${stateDir}/${name}
 
-            ln -sTf ${runner} current
-            chown -h ${user}:${group} . current
-          ''
-          # Including the toplevel here is crucial to have the service definition
-          # change when the host is rebuilt and the vm definition changed.
-          + lib.optionalString (!isFlake) ''
-            ln -sTf ${guestConfig.system.build.toplevel} toplevel
-          ''
-          # Declarative deployment requires storing just the flake
-          + lib.optionalString isFlake ''
-            echo '${if updateFlake != null
-                    then updateFlake
-                    else flake}' > flake
-            chown -h ${user}:${group} flake
+              ln -sTf ${runner} current
+              chown -h ${user}:${group} . current
+            ''
+            # Including the toplevel here is crucial to have the service definition
+            # change when the host is rebuilt and the vm definition changed.
+            + lib.optionalString (!isFlake) ''
+              ln -sTf ${guestConfig.system.build.toplevel} toplevel
+            ''
+            # Declarative deployment requires storing just the flake
+            + lib.optionalString isFlake ''
+              echo '${if updateFlake != null
+                      then updateFlake
+                      else flake}' > flake
+              chown -h ${user}:${group} flake
+            '';
+            serviceConfig.SyslogIdentifier = "install-microvm-${name}";
+          };
+          "microvm@${name}" = {
+            # restartIfChanged is opt-out, so we have to include the definition unconditionally
+            serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
+            path = lib.mkForce [ ];
+            # If the given declarative microvm wants to be restarted on change,
+            # We have to make sure this service group is restarted. To make sure
+            # that this service is also changed when the microvm configuration changes,
+            # we also have to include a trigger here.
+            restartTriggers = [ guestConfig.system.build.toplevel ];
+            overrideStrategy = "asDropin";
+          };
+          "microvm-tap-interfaces@${name}" = {
+            serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
+            path = lib.mkForce [ ];
+            overrideStrategy = "asDropin";
+          };
+          "microvm-pci-devices@${name}" = {
+            serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
+            path = lib.mkForce [ ];
+            overrideStrategy = "asDropin";
+          };
+          "microvm-virtiofsd@${name}" = {
+            serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
+            path = lib.mkForce [ ];
+            overrideStrategy = "asDropin";
+          };
+        }
+      ))
+      {
+        "microvm-tap-interfaces@" = {
+          description = "Setup MicroVM '%i' TAP interfaces";
+          before = [ "microvm@%i.service" ];
+          partOf = [ "microvm@%i.service" ];
+          unitConfig.ConditionPathExists = "${stateDir}/%i/current/share/microvm/tap-interfaces";
+          restartIfChanged = false;
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStop =
+              let
+                stopScript = pkgs.writeScript "stop-microvm-tap-interfaces" ''
+                  #! ${pkgs.runtimeShell} -e
+
+                  cd ${stateDir}/$1
+                  for id in $(cat current/share/microvm/tap-interfaces); do
+                    ${pkgs.iproute2}/bin/ip tuntap del name $id mode tap
+                  done
+                '';
+              in
+              "${stopScript} %i";
+            SyslogIdentifier = "microvm-tap-interfaces@%i";
+          };
+          # `ExecStart`
+          scriptArgs = "%i";
+          script = ''
+            cd ${stateDir}/$1
+            TAP_FLAGS="$(cat current/share/microvm/tap-flags)"
+
+            for id in $(cat current/share/microvm/tap-interfaces); do
+              if [ -e /sys/class/net/$id ]; then
+                ${pkgs.iproute2}/bin/ip tuntap del name $id mode tap $TAP_FLAGS
+              fi
+
+              ${pkgs.iproute2}/bin/ip tuntap add name $id mode tap user ${user} $TAP_FLAGS
+              ${pkgs.iproute2}/bin/ip link set $id up
+            done
           '';
-        serviceConfig.SyslogIdentifier = "install-microvm-${name}";
-      };
-      "microvm@${name}" = {
-        # restartIfChanged is opt-out, so we have to include the definition unconditionally
-        serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
-        path = lib.mkForce [];
-        # If the given declarative microvm wants to be restarted on change,
-        # We have to make sure this service group is restarted. To make sure
-        # that this service is also changed when the microvm configuration changes,
-        # we also have to include a trigger here.
-        restartTriggers = [guestConfig.system.build.toplevel];
-        overrideStrategy = "asDropin";
-      };
-      "microvm-tap-interfaces@${name}" = {
-        serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
-        path = lib.mkForce [];
-        overrideStrategy = "asDropin";
-      };
-      "microvm-pci-devices@${name}" = {
-        serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
-        path = lib.mkForce [];
-        overrideStrategy = "asDropin";
-      };
-      "microvm-virtiofsd@${name}" = {
-        serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
-        path = lib.mkForce [];
-        overrideStrategy = "asDropin";
-      };
-    })) {
-      "microvm-tap-interfaces@" = {
-        description = "Setup MicroVM '%i' TAP interfaces";
-        before = [ "microvm@%i.service" ];
-        partOf = [ "microvm@%i.service" ];
-        unitConfig.ConditionPathExists = "${stateDir}/%i/current/share/microvm/tap-interfaces";
-        restartIfChanged = false;
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          ExecStop =
-            let
-              stopScript = pkgs.writeScript "stop-microvm-tap-interfaces" ''
-                #! ${pkgs.runtimeShell} -e
-
-                cd ${stateDir}/$1
-                for id in $(cat current/share/microvm/tap-interfaces); do
-                  ${pkgs.iproute2}/bin/ip tuntap del name $id mode tap
-                done
-              '';
-            in "${stopScript} %i";
-          SyslogIdentifier = "microvm-tap-interfaces@%i";
         };
-        # `ExecStart`
-        scriptArgs = "%i";
-        script = ''
-          cd ${stateDir}/$1
-          TAP_FLAGS="$(cat current/share/microvm/tap-flags)"
 
-          for id in $(cat current/share/microvm/tap-interfaces); do
-            if [ -e /sys/class/net/$id ]; then
-              ${pkgs.iproute2}/bin/ip tuntap del name $id mode tap $TAP_FLAGS
-            fi
-
-            ${pkgs.iproute2}/bin/ip tuntap add name $id mode tap user ${user} $TAP_FLAGS
-            ${pkgs.iproute2}/bin/ip link set $id up
-          done
-        '';
-      };
-
-      "microvm-macvtap-interfaces@" = {
-        description = "Setup MicroVM '%i' MACVTAP interfaces";
-        before = [ "microvm@%i.service" ];
-        partOf = [ "microvm@%i.service" ];
-        unitConfig.ConditionPathExists = "${stateDir}/%i/current/share/microvm/macvtap-interfaces";
-        restartIfChanged = false;
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          ExecStop =
-            let
-              stopScript = pkgs.writeScript "stop-microvm-tap-interfaces" ''
-                #! ${pkgs.runtimeShell} -e
-                cd ${stateDir}/$1
-                cat current/share/microvm/macvtap-interfaces | while read -r line;do
-                  opts=( $line )
-                  id="''${opts[0]}"
-                  ${pkgs.iproute2}/bin/ip link del name $id
-                done
-              '';
-            in "${stopScript} %i";
-          SyslogIdentifier = "microvm-macvtap-interfaces@%i";
+        "microvm-macvtap-interfaces@" = {
+          description = "Setup MicroVM '%i' MACVTAP interfaces";
+          before = [ "microvm@%i.service" ];
+          partOf = [ "microvm@%i.service" ];
+          unitConfig.ConditionPathExists = "${stateDir}/%i/current/share/microvm/macvtap-interfaces";
+          restartIfChanged = false;
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStop =
+              let
+                stopScript = pkgs.writeScript "stop-microvm-tap-interfaces" ''
+                  #! ${pkgs.runtimeShell} -e
+                  cd ${stateDir}/$1
+                  cat current/share/microvm/macvtap-interfaces | while read -r line;do
+                    opts=( $line )
+                    id="''${opts[0]}"
+                    ${pkgs.iproute2}/bin/ip link del name $id
+                  done
+                '';
+              in
+              "${stopScript} %i";
+            SyslogIdentifier = "microvm-macvtap-interfaces@%i";
+          };
+          # `ExecStart`
+          scriptArgs = "%i";
+          script = ''
+            cd ${stateDir}/$1
+            i=0
+            cat current/share/microvm/macvtap-interfaces | while read -r line;do
+              opts=( $line )
+              id="''${opts[0]}"
+              mac="''${opts[1]}"
+              link="''${opts[2]}"
+              mode="''${opts[3]:+" mode ''${opts[3]}"}"
+              if [ -e /sys/class/net/$id ]; then
+                ${pkgs.iproute2}/bin/ip link del name $id
+              fi
+              ${pkgs.iproute2}/bin/ip link add link $link name $id address $mac type macvtap ''${mode[@]}
+              ${pkgs.iproute2}/bin/ip link set $id allmulticast on
+              echo 1 > /proc/sys/net/ipv6/conf/$id/disable_ipv6
+              ${pkgs.iproute2}/bin/ip link set $id up
+              ${pkgs.coreutils-full}/bin/chown ${user}:${group} /dev/tap$(< /sys/class/net/$id/ifindex)
+            done
+          '';
         };
-        # `ExecStart`
-        scriptArgs = "%i";
-        script = ''
-          cd ${stateDir}/$1
-          i=0
-          cat current/share/microvm/macvtap-interfaces | while read -r line;do
-            opts=( $line )
-            id="''${opts[0]}"
-            mac="''${opts[1]}"
-            link="''${opts[2]}"
-            mode="''${opts[3]:+" mode ''${opts[3]}"}"
-            if [ -e /sys/class/net/$id ]; then
-              ${pkgs.iproute2}/bin/ip link del name $id
-            fi
-            ${pkgs.iproute2}/bin/ip link add link $link name $id address $mac type macvtap ''${mode[@]}
-            ${pkgs.iproute2}/bin/ip link set $id allmulticast on
-            echo 1 > /proc/sys/net/ipv6/conf/$id/disable_ipv6
-            ${pkgs.iproute2}/bin/ip link set $id up
-            ${pkgs.coreutils-full}/bin/chown ${user}:${group} /dev/tap$(< /sys/class/net/$id/ifindex)
-          done
-        '';
-      };
 
 
-      "microvm-pci-devices@" = {
-        description = "Setup MicroVM '%i' devices for passthrough";
-        before = [ "microvm@%i.service" ];
-        partOf = [ "microvm@%i.service" ];
-        unitConfig.ConditionPathExists = "${stateDir}/%i/current/share/microvm/pci-devices";
-        restartIfChanged = false;
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          SyslogIdentifier = "microvm-pci-devices@%i";
+        "microvm-pci-devices@" = {
+          description = "Setup MicroVM '%i' devices for passthrough";
+          before = [ "microvm@%i.service" ];
+          partOf = [ "microvm@%i.service" ];
+          unitConfig.ConditionPathExists = "${stateDir}/%i/current/share/microvm/pci-devices";
+          restartIfChanged = false;
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            SyslogIdentifier = "microvm-pci-devices@%i";
+          };
+          # `ExecStart`
+          scriptArgs = "%i";
+          script = ''
+            cd ${stateDir}/$1
+
+            ${pkgs.kmod}/bin/modprobe vfio-pci
+
+            for path in $(cat current/share/microvm/pci-devices); do
+              pushd /sys/bus/pci/devices/$path
+              if [ -e driver ]; then
+                echo $path > driver/unbind
+              fi
+              echo vfio-pci > driver_override
+              echo $path > /sys/bus/pci/drivers_probe
+
+              # In order to access the vfio dev the permissions must be set
+              # for the user/group running the VMM later.
+              #
+              # Insprired by https://www.kernel.org/doc/html/next/driver-api/vfio.html#vfio-usage-example
+              #
+              # assert we could get the IOMMU group number (=: name of VFIO dev)
+              [[ -e iommu_group ]] || exit 1
+              VFIO_DEV=$(basename $(readlink iommu_group))
+              echo "Making VFIO device $VFIO_DEV accessible for user"
+              chown ${user}:${group} /dev/vfio/$VFIO_DEV
+              popd
+            done
+          '';
         };
-        # `ExecStart`
-        scriptArgs = "%i";
-        script = ''
-          cd ${stateDir}/$1
 
-          ${pkgs.kmod}/bin/modprobe vfio-pci
+        "microvm-virtiofsd@" = rec {
+          description = "VirtioFS daemons for MicroVM '%i'";
+          before = [ "microvm@%i.service" ];
+          after = [ "local-fs.target" ];
+          partOf = [ "microvm@%i.service" ];
+          unitConfig.ConditionPathExists = "${stateDir}/%i/current/share/microvm/virtiofs";
+          restartIfChanged = false;
+          serviceConfig = {
+            Type = "forking";
+            GuessMainPID = "no";
+            WorkingDirectory = "${stateDir}/%i";
+            Restart = "always";
+            RestartSec = "5s";
+            SyslogIdentifier = "microvm-virtiofsd@%i";
+            LimitNOFILE = 1048576;
+          };
+          path = with pkgs; [ coreutils virtiofsd ];
+          script = ''
+            for d in current/share/microvm/virtiofs/*; do
+              SOCKET=$(cat $d/socket)
+              SOURCE="$(cat $d/source)"
+              mkdir -p "$SOURCE"
 
-          for path in $(cat current/share/microvm/pci-devices); do
-            pushd /sys/bus/pci/devices/$path
-            if [ -e driver ]; then
-              echo $path > driver/unbind
-            fi
-            echo vfio-pci > driver_override
-            echo $path > /sys/bus/pci/drivers_probe
-
-            # In order to access the vfio dev the permissions must be set
-            # for the user/group running the VMM later.
-            #
-            # Insprired by https://www.kernel.org/doc/html/next/driver-api/vfio.html#vfio-usage-example
-            #
-            # assert we could get the IOMMU group number (=: name of VFIO dev)
-            [[ -e iommu_group ]] || exit 1
-            VFIO_DEV=$(basename $(readlink iommu_group))
-            echo "Making VFIO device $VFIO_DEV accessible for user"
-            chown ${user}:${group} /dev/vfio/$VFIO_DEV
-            popd
-          done
-        '';
-      };
-
-      "microvm-virtiofsd@" = rec {
-        description = "VirtioFS daemons for MicroVM '%i'";
-        before = [ "microvm@%i.service" ];
-        after = [ "local-fs.target" ];
-        partOf = [ "microvm@%i.service" ];
-        unitConfig.ConditionPathExists = "${stateDir}/%i/current/share/microvm/virtiofs";
-        restartIfChanged = false;
-        serviceConfig = {
-          Type = "forking";
-          GuessMainPID = "no";
-          WorkingDirectory = "${stateDir}/%i";
-          Restart = "always";
-          RestartSec = "5s";
-          SyslogIdentifier = "microvm-virtiofsd@%i";
-          LimitNOFILE = 1048576;
+              virtiofsd \
+                --socket-path=$SOCKET \
+                --socket-group=${config.users.users.microvm.group} \
+                --shared-dir "$SOURCE" \
+                --rlimit-nofile ${toString serviceConfig.LimitNOFILE} \
+                --thread-pool-size `nproc` \
+                --posix-acl --xattr \
+                &
+              # detach from shell, but remain in systemd cgroup
+              disown
+            done
+          '';
         };
-        path = with pkgs; [ coreutils virtiofsd ];
-        script = ''
-          for d in current/share/microvm/virtiofs/*; do
-            SOCKET=$(cat $d/socket)
-            SOURCE="$(cat $d/source)"
-            mkdir -p "$SOURCE"
 
-            virtiofsd \
-              --socket-path=$SOCKET \
-              --socket-group=${config.users.users.microvm.group} \
-              --shared-dir "$SOURCE" \
-              --rlimit-nofile ${toString serviceConfig.LimitNOFILE} \
-              --thread-pool-size `nproc` \
-              --posix-acl --xattr \
-              &
-            # detach from shell, but remain in systemd cgroup
-            disown
-          done
-        '';
-      };
-
-      "microvm@" = {
-        description = "MicroVM '%i'";
-        requires = [
-          "microvm-tap-interfaces@%i.service"
-          "microvm-macvtap-interfaces@%i.service"
-          "microvm-pci-devices@%i.service"
-          "microvm-virtiofsd@%i.service"
-        ];
-        after = [ "network.target" ];
-        unitConfig.ConditionPathExists = "${stateDir}/%i/current/bin/microvm-run";
-        restartIfChanged = false;
-        preStart = ''
-          rm -f booted
-          ln -s $(readlink current) booted
-        '';
-        postStop = ''
-          rm booted
-        '';
-        serviceConfig = {
-          Type = "simple";
-          WorkingDirectory = "${stateDir}/%i";
-          ExecStart = "${stateDir}/%i/current/bin/microvm-run";
-          ExecStop = "${stateDir}/%i/booted/bin/microvm-shutdown";
-          TimeoutStopSec = 90;
-          Restart = "always";
-          RestartSec = "5s";
-          User = user;
-          Group = group;
-          SyslogIdentifier = "microvm@%i";
-          LimitNOFILE = 1048576;
-          LimitMEMLOCK = "infinity";
+        "microvm@" = {
+          description = "MicroVM '%i'";
+          requires = [
+            "microvm-tap-interfaces@%i.service"
+            "microvm-macvtap-interfaces@%i.service"
+            "microvm-pci-devices@%i.service"
+            "microvm-virtiofsd@%i.service"
+          ];
+          after = [ "network.target" ];
+          unitConfig.ConditionPathExists = "${stateDir}/%i/current/bin/microvm-run";
+          restartIfChanged = false;
+          preStart = ''
+            rm -f booted
+            ln -s $(readlink current) booted
+          '';
+          postStop = ''
+            rm booted
+          '';
+          serviceConfig = {
+            Type = "simple";
+            WorkingDirectory = "${stateDir}/%i";
+            ExecStart = "${stateDir}/%i/current/bin/microvm-run";
+            ExecStop = "${stateDir}/%i/booted/bin/microvm-shutdown";
+            TimeoutStopSec = 90;
+            Restart = "always";
+            RestartSec = "5s";
+            User = user;
+            Group = group;
+            SyslogIdentifier = "microvm@%i";
+            LimitNOFILE = 1048576;
+            LimitMEMLOCK = "infinity";
+          };
         };
-      };
-    } (builtins.attrNames config.microvm.vms);
+      }
+      (builtins.attrNames config.microvm.vms);
 
-    microvm.autostart = builtins.filter (vmName:
-      config.microvm.vms.${vmName}.autostart
-    ) (builtins.attrNames config.microvm.vms);
+    microvm.autostart = builtins.filter
+      (vmName:
+        config.microvm.vms.${vmName}.autostart
+      )
+      (builtins.attrNames config.microvm.vms);
     # Starts all the containers after boot
     systemd.targets.microvms = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos-modules/microvm/asserts.nix
+++ b/nixos-modules/microvm/asserts.nix
@@ -6,106 +6,120 @@ in
 lib.mkIf config.microvm.guest.enable {
   assertions =
     # check for duplicate volume images
-    map (volumes: {
-      assertion = builtins.length volumes == 1;
-      message = ''
-        MicroVM ${hostName}: volume image "${(builtins.head volumes).image}" is used ${toString (builtins.length volumes)} > 1 times.
-      '';
-    }) (
-      builtins.attrValues (
-        builtins.groupBy ({ image, ... }: image) config.microvm.volumes
-      )
-    )
-    ++
-    # check for duplicate interface ids
-    map (interfaces: {
-      assertion = builtins.length interfaces == 1;
-      message = ''
-        MicroVM ${hostName}: interface id "${(builtins.head interfaces).id}" is used ${toString (builtins.length interfaces)} > 1 times.
-      '';
-    }) (
-      builtins.attrValues (
-        builtins.groupBy ({ id, ... }: id) config.microvm.interfaces
-      )
-    )
-    ++
-    # check for bridge interfaces
-    map ({ id, type, bridge, ... }:
-      if type == "bridge"
-      then {
-        assertion = bridge != null;
+    map
+      (volumes: {
+        assertion = builtins.length volumes == 1;
         message = ''
-          MicroVM ${hostName}: interface ${id} is of type "bridge"
-          but doesn't have a bridge to attach to defined.
+          MicroVM ${hostName}: volume image "${(builtins.head volumes).image}" is used ${toString (builtins.length volumes)} > 1 times.
         '';
-      }
-      else {
-        assertion = bridge == null;
-        message = ''
-          MicroVM ${hostName}: interface ${id} is not of type "bridge"
-          and therefore shouldn't have a "bridge" option defined.
-        '';
-      }
-    ) config.microvm.interfaces
-    ++
-    # check for interface name length
-    map ({ id, ... }: {
-      assertion = builtins.stringLength id <= 15;
-      message = ''
-        MicroVM ${hostName}: interface name ${id} is longer than the
-        the maximum length of 15 characters on Linux.
-      '';
-    }) config.microvm.interfaces
-    ++
-    # check for duplicate share tags
-    map (shares: {
-      assertion = builtins.length shares == 1;
-      message = ''
-        MicroVM ${hostName}: share tag "${(builtins.head shares).tag}" is used ${toString (builtins.length shares)} > 1 times.
-      '';
-    }) (
-      builtins.attrValues (
-        builtins.groupBy ({ tag, ... }: tag) config.microvm.shares
-      )
-    )
-    ++
-    # check for duplicate share sockets
-    map (shares: {
-      assertion = builtins.length shares == 1;
-      message = ''
-        MicroVM ${hostName}: share socket "${(builtins.head shares).socket}" is used ${toString (builtins.length shares)} > 1 times.
-      '';
-    }) (
-      builtins.attrValues (
-        builtins.groupBy ({ socket, ... }: toString socket) (
-          builtins.filter ({ proto, ... }: proto == "virtiofs")
-            config.microvm.shares
+      })
+      (
+        builtins.attrValues (
+          builtins.groupBy ({ image, ... }: image) config.microvm.volumes
         )
       )
-    )
+    ++
+    # check for duplicate interface ids
+    map
+      (interfaces: {
+        assertion = builtins.length interfaces == 1;
+        message = ''
+          MicroVM ${hostName}: interface id "${(builtins.head interfaces).id}" is used ${toString (builtins.length interfaces)} > 1 times.
+        '';
+      })
+      (
+        builtins.attrValues (
+          builtins.groupBy ({ id, ... }: id) config.microvm.interfaces
+        )
+      )
+    ++
+    # check for bridge interfaces
+    map
+      ({ id, type, bridge, ... }:
+        if type == "bridge"
+        then {
+          assertion = bridge != null;
+          message = ''
+            MicroVM ${hostName}: interface ${id} is of type "bridge"
+            but doesn't have a bridge to attach to defined.
+          '';
+        }
+        else {
+          assertion = bridge == null;
+          message = ''
+            MicroVM ${hostName}: interface ${id} is not of type "bridge"
+            and therefore shouldn't have a "bridge" option defined.
+          '';
+        }
+      )
+      config.microvm.interfaces
+    ++
+    # check for interface name length
+    map
+      ({ id, ... }: {
+        assertion = builtins.stringLength id <= 15;
+        message = ''
+          MicroVM ${hostName}: interface name ${id} is longer than the
+          the maximum length of 15 characters on Linux.
+        '';
+      })
+      config.microvm.interfaces
+    ++
+    # check for duplicate share tags
+    map
+      (shares: {
+        assertion = builtins.length shares == 1;
+        message = ''
+          MicroVM ${hostName}: share tag "${(builtins.head shares).tag}" is used ${toString (builtins.length shares)} > 1 times.
+        '';
+      })
+      (
+        builtins.attrValues (
+          builtins.groupBy ({ tag, ... }: tag) config.microvm.shares
+        )
+      )
+    ++
+    # check for duplicate share sockets
+    map
+      (shares: {
+        assertion = builtins.length shares == 1;
+        message = ''
+          MicroVM ${hostName}: share socket "${(builtins.head shares).socket}" is used ${toString (builtins.length shares)} > 1 times.
+        '';
+      })
+      (
+        builtins.attrValues (
+          builtins.groupBy ({ socket, ... }: toString socket) (
+            builtins.filter ({ proto, ... }: proto == "virtiofs")
+              config.microvm.shares
+          )
+        )
+      )
     ++
     # check for virtiofs shares without socket
-    map ({ tag, socket, ... }: {
-      assertion = socket != null;
-      message = ''
-        MicroVM ${hostName}: virtiofs share with tag "${tag}" is missing a `socket` path.
-      '';
-    }) (
-      builtins.filter ({ proto, ... }: proto == "virtiofs")
-        config.microvm.shares
-    )
+    map
+      ({ tag, socket, ... }: {
+        assertion = socket != null;
+        message = ''
+          MicroVM ${hostName}: virtiofs share with tag "${tag}" is missing a `socket` path.
+        '';
+      })
+      (
+        builtins.filter ({ proto, ... }: proto == "virtiofs")
+          config.microvm.shares
+      )
     ++
     # blacklist forwardPorts
-    [ {
+    [{
       assertion =
-        config.microvm.forwardPorts != [] -> (
+        config.microvm.forwardPorts != [ ] -> (
           config.microvm.hypervisor == "qemu" &&
           builtins.any ({ type, ... }: type == "user") config.microvm.interfaces
         );
       message = ''
         MicroVM ${hostName}: `config.microvm.forwardPorts` works only with qemu and one network interface with `type = "user"`
       '';
-    } ];
+    }];
 
   warnings =
     # 32 MB is just an optimistic guess, not based on experience

--- a/nixos-modules/microvm/boot-disk.nix
+++ b/nixos-modules/microvm/boot-disk.nix
@@ -7,7 +7,8 @@ let
   kernelPath =
     "${config.microvm.kernel}/${kernelFile}";
 
-in {
+in
+{
   options.microvm = with lib; {
     bootDisk = mkOption {
       type = types.path;
@@ -21,13 +22,14 @@ in {
   };
 
   config = lib.mkIf config.microvm.guest.enable {
-    microvm.bootDisk = pkgs.runCommandLocal "microvm-bootdisk.img" {
-      nativeBuildInputs = with pkgs; [
-        parted
-        libguestfs
-      ];
-      LIBGUESTFS_PATH = pkgs.libguestfs-appliance;
-    } ''
+    microvm.bootDisk = pkgs.runCommandLocal "microvm-bootdisk.img"
+      {
+        nativeBuildInputs = with pkgs; [
+          parted
+          libguestfs
+        ];
+        LIBGUESTFS_PATH = pkgs.libguestfs-appliance;
+      } ''
       # kernel + initrd + slack, in sectors
       EFI_SIZE=$(( ( ( $(stat -c %s ${kernelPath}) + $(stat -c %s ${initrdPath}) + 16 * 4096 ) / ( 2048 * 512 ) + 1 ) * 2048 ))
 

--- a/nixos-modules/microvm/graphics.nix
+++ b/nixos-modules/microvm/graphics.nix
@@ -21,6 +21,8 @@ lib.mkIf config.microvm.graphics.enable {
   boot.kernelModules = [ "drm" "virtio_gpu" ];
 
   environment.systemPackages = with pkgs; [
-    run-sommelier run-wayland-proxy run-waypipe
+    run-sommelier
+    run-wayland-proxy
+    run-waypipe
   ];
 }

--- a/nixos-modules/microvm/mounts.nix
+++ b/nixos-modules/microvm/mounts.nix
@@ -8,9 +8,11 @@ let
   }) defaultFsType withDriveLetters;
 
   hostStore = builtins.head (
-    builtins.filter ({ source, ... }:
-      source == "/nix/store"
-    ) config.microvm.shares
+    builtins.filter
+      ({ source, ... }:
+        source == "/nix/store"
+      )
+      config.microvm.shares
   );
 
   roStore =
@@ -29,104 +31,125 @@ let
 
 in
 lib.mkIf config.microvm.guest.enable {
-  fileSystems = lib.mkMerge [ (
-    # built-in read-only store without overlay
-    lib.optionalAttrs (
-      storeOnDisk &&
-      writableStoreOverlay == null
-    ) {
-      "/nix/store" = {
-        device = roStoreDisk;
-        fsType = storeDiskType;
-        options = [ "x-systemd.requires=systemd-modules-load.service" ];
-        neededForBoot = true;
-      };
-    }
-  ) (
-    # host store is mounted somewhere else,
-    # bind-mount to the proper place
-    lib.optionalAttrs (
-      !storeOnDisk &&
-      config.microvm.writableStoreOverlay == null &&
-      hostStore.mountPoint != "/nix/store"
-    ) {
-      "/nix/store" = {
-        device = hostStore.mountPoint;
-        options = [ "bind" ];
-        neededForBoot = true;
-      };
-    }
-  ) (
-    # built-in read-only store for the overlay
-    lib.optionalAttrs (
-      storeOnDisk &&
-      writableStoreOverlay != null
-    ) {
-      "/nix/.ro-store" = {
-        device = roStoreDisk;
-        fsType = storeDiskType;
-        options = [ "x-systemd.requires=systemd-modules-load.service" ];
-        neededForBoot = true;
-      };
-    }
-  ) (
-    # mount store with writable overlay
-    lib.optionalAttrs (writableStoreOverlay != null) {
-      "/nix/store" = {
-        device = "overlay";
-        fsType = "overlay";
-        neededForBoot = true;
-        options = [
-          "lowerdir=${roStore}"
-          "upperdir=${writableStoreOverlay}/store"
-          "workdir=${writableStoreOverlay}/work"
-        ];
-        depends = [ roStore writableStoreOverlay ];
-      };
-    }
-  ) {
-    # a tmpfs / by default. can be overwritten.
-    "/" = lib.mkDefault {
-      device = "rootfs";
-      fsType = "tmpfs";
-      options = [ "size=50%,mode=0755" ];
-      neededForBoot = true;
-    };
-  } (
-    # Volumes
-    builtins.foldl' (result: { label, mountPoint, letter, fsType ? defaultFsType, ... }:
-      result // lib.optionalAttrs (mountPoint != null) {
-        "${mountPoint}" = {
-          inherit fsType;
-          # Prioritize identifying a device by label if provided. This
-          # minimizes the risk of misidentifying a device.
-          device = if label != null then
-            "/dev/disk/by-label/${label}"
-          else
-            "/dev/vd${letter}";
-        } // lib.optionalAttrs (mountPoint == config.microvm.writableStoreOverlay) {
+  fileSystems = lib.mkMerge [
+    (
+      # built-in read-only store without overlay
+      lib.optionalAttrs
+        (
+          storeOnDisk &&
+          writableStoreOverlay == null
+        )
+        {
+          "/nix/store" = {
+            device = roStoreDisk;
+            fsType = storeDiskType;
+            options = [ "x-systemd.requires=systemd-modules-load.service" ];
+            neededForBoot = true;
+          };
+        }
+    )
+    (
+      # host store is mounted somewhere else,
+      # bind-mount to the proper place
+      lib.optionalAttrs
+        (
+          !storeOnDisk &&
+          config.microvm.writableStoreOverlay == null &&
+          hostStore.mountPoint != "/nix/store"
+        )
+        {
+          "/nix/store" = {
+            device = hostStore.mountPoint;
+            options = [ "bind" ];
+            neededForBoot = true;
+          };
+        }
+    )
+    (
+      # built-in read-only store for the overlay
+      lib.optionalAttrs
+        (
+          storeOnDisk &&
+          writableStoreOverlay != null
+        )
+        {
+          "/nix/.ro-store" = {
+            device = roStoreDisk;
+            fsType = storeDiskType;
+            options = [ "x-systemd.requires=systemd-modules-load.service" ];
+            neededForBoot = true;
+          };
+        }
+    )
+    (
+      # mount store with writable overlay
+      lib.optionalAttrs (writableStoreOverlay != null) {
+        "/nix/store" = {
+          device = "overlay";
+          fsType = "overlay";
           neededForBoot = true;
+          options = [
+            "lowerdir=${roStore}"
+            "upperdir=${writableStoreOverlay}/store"
+            "workdir=${writableStoreOverlay}/work"
+          ];
+          depends = [ roStore writableStoreOverlay ];
         };
-      }) {} (withDriveLetters config.microvm)
-  ) (
-    # 9p/virtiofs Shares
-    builtins.foldl' (result: { mountPoint, tag, proto, source, ... }: result // {
-      "${mountPoint}" = {
-        device = tag;
-        fsType = proto;
-        options = {
-          "virtiofs" = [ "defaults" "x-systemd.requires=systemd-modules-load.service" ];
-          "9p" = [ "trans=virtio" "version=9p2000.L" "msize=65536" "x-systemd.requires=systemd-modules-load.service" ];
-        }.${proto};
-      } // lib.optionalAttrs (source == "/nix/store" || mountPoint == config.microvm.writableStoreOverlay) {
+      }
+    )
+    {
+      # a tmpfs / by default. can be overwritten.
+      "/" = lib.mkDefault {
+        device = "rootfs";
+        fsType = "tmpfs";
+        options = [ "size=50%,mode=0755" ];
         neededForBoot = true;
       };
-    }) {} config.microvm.shares
-  ) ];
+    }
+    (
+      # Volumes
+      builtins.foldl'
+        (result: { label, mountPoint, letter, fsType ? defaultFsType, ... }:
+          result // lib.optionalAttrs (mountPoint != null) {
+            "${mountPoint}" = {
+              inherit fsType;
+              # Prioritize identifying a device by label if provided. This
+              # minimizes the risk of misidentifying a device.
+              device =
+                if label != null then
+                  "/dev/disk/by-label/${label}"
+                else
+                  "/dev/vd${letter}";
+            } // lib.optionalAttrs (mountPoint == config.microvm.writableStoreOverlay) {
+              neededForBoot = true;
+            };
+          })
+        { }
+        (withDriveLetters config.microvm)
+    )
+    (
+      # 9p/virtiofs Shares
+      builtins.foldl'
+        (result: { mountPoint, tag, proto, source, ... }: result // {
+          "${mountPoint}" = {
+            device = tag;
+            fsType = proto;
+            options = {
+              "virtiofs" = [ "defaults" "x-systemd.requires=systemd-modules-load.service" ];
+              "9p" = [ "trans=virtio" "version=9p2000.L" "msize=65536" "x-systemd.requires=systemd-modules-load.service" ];
+            }.${proto};
+          } // lib.optionalAttrs (source == "/nix/store" || mountPoint == config.microvm.writableStoreOverlay) {
+            neededForBoot = true;
+          };
+        })
+        { }
+        config.microvm.shares
+    )
+  ];
 
   # boot.initrd.systemd patchups copied from <nixpkgs/nixos/modules/virtualisation/qemu-vm.nix>
   boot.initrd.systemd = lib.mkIf (config.boot.initrd.systemd.enable && writableStoreOverlay != null) {
-    mounts = [ {
+    mounts = [{
       where = "/sysroot/nix/store";
       what = "overlay";
       type = "overlay";
@@ -140,7 +163,7 @@ lib.mkIf config.microvm.guest.enable {
       requires = [ "rw-store.service" ];
       after = [ "rw-store.service" ];
       unitConfig.RequiresMountsFor = "/sysroot/${roStore}";
-    } ];
+    }];
     services.rw-store = {
       unitConfig = {
         DefaultDependencies = false;
@@ -154,11 +177,11 @@ lib.mkIf config.microvm.guest.enable {
   };
 
   # Fix for hanging shutdown
-  systemd.mounts = lib.mkIf config.boot.initrd.systemd.enable [ {
+  systemd.mounts = lib.mkIf config.boot.initrd.systemd.enable [{
     what = "store";
     where = "/nix/store";
     # Generate a `nix-store.mount.d/overrides.conf`
     overrideStrategy = "asDropin";
     unitConfig.DefaultDependencies = false;
-  } ];
+  }];
 }

--- a/nixos-modules/microvm/optimization.nix
+++ b/nixos-modules/microvm/optimization.nix
@@ -8,9 +8,11 @@ let
   canSwitchViaSsh =
     config.services.openssh.enable &&
     # Is the /nix/store mounted from the host?
-    builtins.any ({ source, ... }:
-      source == "/nix/store"
-    ) config.microvm.shares;
+    builtins.any
+      ({ source, ... }:
+        source == "/nix/store"
+      )
+      config.microvm.shares;
 
 in
 {
@@ -45,7 +47,8 @@ in
         "cloud-hypervisor"
         "firecracker"
         "stratovirt"
-      ]);
+      ]
+    );
 
     nixpkgs.overlays = [
       (final: prev: {

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -144,18 +144,18 @@ in
             description = "The guest port to be mapped.";
           };
         });
-      default = [];
+      default = [ ];
       example = lib.literalExpression
         ''
-        [ # forward local port 2222 -> 22, to ssh into the VM
-          { from = "host"; host.port = 2222; guest.port = 22; }
+          [ # forward local port 2222 -> 22, to ssh into the VM
+            { from = "host"; host.port = 2222; guest.port = 22; }
 
-          # forward local port 80 -> 10.0.2.10:80 in the VLAN
-          { from = "guest";
-            guest.address = "10.0.2.10"; guest.port = 80;
-            host.address = "127.0.0.1"; host.port = 80;
-          }
-        ]
+            # forward local port 80 -> 10.0.2.10:80 in the VLAN
+            { from = "guest";
+              guest.address = "10.0.2.10"; guest.port = 80;
+              host.address = "127.0.0.1"; host.port = 80;
+            }
+          ]
         '';
       description =
         ''
@@ -173,7 +173,7 @@ in
     };
     volumes = mkOption {
       description = "Disk images";
-      default = [];
+      default = [ ];
       type = with types; listOf (submodule {
         options = {
           image = mkOption {
@@ -209,7 +209,7 @@ in
 
     interfaces = mkOption {
       description = "Network interfaces";
-      default = [];
+      default = [ ];
       type = with types; listOf (submodule {
         options = {
           type = mkOption {
@@ -232,7 +232,7 @@ in
             '';
           };
           macvtap.mode = mkOption {
-            type = nullOr (enum ["private" "vepa" "bridge" "passthru" "source"]);
+            type = nullOr (enum [ "private" "vepa" "bridge" "passthru" "source" ]);
             default = null;
             description = ''
               The MACVLAN mode to use
@@ -257,7 +257,7 @@ in
 
     shares = mkOption {
       description = "Shared directory trees";
-      default = [];
+      default = [ ];
       type = with types; listOf (submodule ({ config, ... }: {
         options = {
           tag = mkOption {
@@ -296,7 +296,7 @@ in
 
     devices = mkOption {
       description = "PCI/USB devices that are passed from the host to the MicroVM";
-      default = [];
+      default = [ ];
       example = literalExpression ''[ {
         bus = "pci";
         path = "0000:01:00.0";
@@ -347,9 +347,11 @@ in
 
     storeOnDisk = mkOption {
       type = types.bool;
-      default = ! lib.any ({ source, ... }:
-        source == "/nix/store"
-      ) config.microvm.shares;
+      default = ! lib.any
+        ({ source, ... }:
+          source == "/nix/store"
+        )
+        config.microvm.shares;
       description = "Whether to boot with the storeDisk, that is, unless the host's /nix/store is a microvm.share.";
     };
 
@@ -395,7 +397,7 @@ in
 
     qemu.extraArgs = mkOption {
       type = with types; listOf str;
-      default = [];
+      default = [ ];
       description = "Extra arguments to pass to qemu.";
     };
 
@@ -409,13 +411,13 @@ in
 
     cloud-hypervisor.extraArgs = mkOption {
       type = with types; listOf str;
-      default = [];
+      default = [ ];
       description = "Extra arguments to pass to cloud-hypervisor.";
     };
 
     crosvm.extraArgs = mkOption {
       type = with types; listOf str;
-      default = [];
+      default = [ ];
       description = "Extra arguments to pass to crosvm.";
     };
 

--- a/nixos-modules/microvm/ssh-deploy.nix
+++ b/nixos-modules/microvm/ssh-deploy.nix
@@ -27,9 +27,11 @@ let
     # MicroVM must be reachable through SSH
     config.services.openssh.enable &&
     # Is the /nix/store mounted from the host?
-    builtins.any ({ source, ... }:
-      source == "/nix/store"
-    ) config.microvm.shares;
+    builtins.any
+      ({ source, ... }:
+        source == "/nix/store"
+      )
+      config.microvm.shares;
 
 in
 {

--- a/nixos-modules/microvm/store-disk.nix
+++ b/nixos-modules/microvm/store-disk.nix
@@ -53,15 +53,18 @@ in
         config.microvm.storeDiskType
       ];
 
-      microvm.storeDisk = pkgs.runCommandLocal "microvm-store-disk.${config.microvm.storeDiskType}" {
-        nativeBuildInputs = with pkgs.buildPackages; [ {
-          squashfs = [ squashfs-tools-ng ];
-          erofs = [ erofs-utils ];
-        }.${config.microvm.storeDiskType} ];
-        passthru = {
-          inherit regInfo;
-        };
-      } ''
+      microvm.storeDisk = pkgs.runCommandLocal "microvm-store-disk.${config.microvm.storeDiskType}"
+        {
+          nativeBuildInputs = with pkgs.buildPackages; [
+            {
+              squashfs = [ squashfs-tools-ng ];
+              erofs = [ erofs-utils ];
+            }.${config.microvm.storeDiskType}
+          ];
+          passthru = {
+            inherit regInfo;
+          };
+        } ''
         echo Copying a /nix/store
         mkdir store
         for d in $(sort -u ${

--- a/nixos-modules/microvm/system.nix
+++ b/nixos-modules/microvm/system.nix
@@ -3,10 +3,13 @@
 {
   config = lib.mkIf config.microvm.guest.enable {
     assertions = [
-      {assertion = (config.microvm.writableStoreOverlay != null) -> (!config.nix.optimise.automatic && !config.nix.settings.auto-optimise-store);
-       message = ''
-         `nix.optimise.automatic` and `nix.settings.auto-optimise-store` do not work with `microvm.writableStoreOverlay`.
-       '';}];
+      {
+        assertion = (config.microvm.writableStoreOverlay != null) -> (!config.nix.optimise.automatic && !config.nix.settings.auto-optimise-store);
+        message = ''
+          `nix.optimise.automatic` and `nix.settings.auto-optimise-store` do not work with `microvm.writableStoreOverlay`.
+        '';
+      }
+    ];
 
 
     boot.loader.grub.enable = false;
@@ -18,10 +21,11 @@
       "9pnet_virtio"
       "9p"
       "virtiofs"
-    ] ++ lib.optionals (
-      pkgs.targetPlatform.system == "x86_64-linux" &&
-      config.microvm.hypervisor == "firecracker"
-    ) [
+    ] ++ lib.optionals
+      (
+        pkgs.targetPlatform.system == "x86_64-linux" &&
+          config.microvm.hypervisor == "firecracker"
+      ) [
       # Keyboard controller that can receive CtrlAltDel
       "i8042"
     ] ++ lib.optionals (config.microvm.writableStoreOverlay != null) [
@@ -34,14 +38,16 @@
 
     # modules that consume boot time but have rare use-cases
     boot.blacklistedKernelModules = [
-      "rfkill" "intel_pstate"
+      "rfkill"
+      "intel_pstate"
     ] ++ lib.optional (!config.microvm.graphics.enable) "drm";
 
     systemd =
       let
         # nix-daemon works only with a writable /nix/store
         enableNixDaemon = config.microvm.writableStoreOverlay != null;
-      in {
+      in
+      {
         services.nix-daemon.enable = lib.mkDefault enableNixDaemon;
         sockets.nix-daemon.enable = lib.mkDefault enableNixDaemon;
 

--- a/pkgs/build-microvm.nix
+++ b/pkgs/build-microvm.nix
@@ -1,9 +1,13 @@
 # Builds a MicroVM from a flake but takes the hypervisor from the
 # local pkgs not from the target flake.
 { self
-, lib, targetPlatform
-, writeScriptBin, runtimeShell
-, coreutils, git, nix
+, lib
+, targetPlatform
+, writeScriptBin
+, runtimeShell
+, coreutils
+, git
+, nix
 }:
 
 writeScriptBin "build-microvm" ''

--- a/pkgs/doc.nix
+++ b/pkgs/doc.nix
@@ -11,7 +11,8 @@ let
   };
 
 in
-runCommand "microvm.nix-doc" {
+runCommand "microvm.nix-doc"
+{
   nativeBuildInputs = [ mdbook ];
 } ''
   cp -r ${../doc} doc


### PR DESCRIPTION
Implements the suggestion from here https://github.com/astro/microvm.nix/issues/35 and uses [`nixpkgs-fmt`](https://github.com/nix-community/nixpkgs-fmt). I opted for it since it looked the least weird. IMO `alejandra` has not enough spacing and `nixfmt` uses a bit too much.

Anyways, feel free to suggest using another formatter. I just want to have a consistent formatting here which I can apply right before committing so that my own auto-formatting isn't getting in the way 😅 

I separated adding the formatter and formatting the code here into two commits so we could optionally omit the latter and do the actual formatting later to prevent merge conflicts.