### PR TITLE
Switch to truncate in createVolumesScript to avoid race conditions and support larger disk allocations

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -55,7 +55,7 @@ rec {
         touch '${image}'
         # Mark NOCOW
         chattr +C '${image}' || true
-        fallocate -l${toString size}MiB '${image}'
+        truncate -s ${toString size}M '${image}'
         mkfs.${fsType} ${labelArgument} '${image}'
       fi
     '')));


### PR DESCRIPTION
See https://github.com/astro/microvm.nix/issues/229