### PR TITLE
Increased microvm default timeout stop to 2m30s.

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -455,7 +455,7 @@ in
           WorkingDirectory = "${stateDir}/%i";
           ExecStart = "${stateDir}/%i/current/bin/microvm-run";
           ExecStop = "${stateDir}/%i/booted/bin/microvm-shutdown";
-          TimeoutStopSec = 90;
+          TimeoutStopSec = 150;
           Restart = "always";
           RestartSec = "5s";
           User = user;


### PR DESCRIPTION
On a low-power i3 box, I keep having a thundering herd issue where my microVMs are _almost_ finished booting when systemd decides to restart them all again.