### PR TITLE
Use xhci instead of ehci for USB

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -270,8 +270,7 @@ in {
     )
     ++
     lib.optionals requireUsb [
-      "-usb"
-      "-device" "usb-ehci"
+      "-device" "qemu-xhci"
     ]
     ++
     builtins.concatMap ({ bus, path, ... }: {


### PR DESCRIPTION
Hello,

I've noticed that microvm.nix adds an EHCI controller for USB forwarding, while the documentation seems to recommend XHCI: https://www.qemu.org/docs/master/system/devices/usb.html#xhci-controller-support

Is there a reason for using EHCI? If so, I am happy to create an option instead.