### PR TITLE
cloud-hypervisor: Remove hardcoded value of console

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -133,7 +133,7 @@ in {
         "--serial" "tty"
         "--kernel" kernelPath
         "--initramfs" initrdPath
-        "--cmdline" "console=ttyS0 reboot=t panic=-1 ${toString microvmConfig.kernelParams}"
+        "--cmdline" "${kernelConsole} reboot=t panic=-1 ${toString microvmConfig.kernelParams}"
         "--seccomp" "true"
         "--memory" memOps
         "--platform" "oem_strings=[io.systemd.credential:vmm.notify_socket=vsock-stream:2:8888]"


### PR DESCRIPTION
We have kernelConsole value already defined but its not being used as argument. So removing hardcoded value and using kernelConsole value, which will fix issue console service crash issue on aarch64.