### PR TITLE
Use smaller qemu-utils for qemu-bridge-helper

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -349,7 +349,7 @@ in
     # This helper creates tap interfaces and attaches them to a bridge
     # for qemu regardless if it is run as root or not.
     security.wrappers.qemu-bridge-helper = lib.mkIf (!config.virtualisation.libvirtd.enable) {
-      source = "${pkgs.qemu}/libexec/qemu-bridge-helper";
+      source = "${pkgs.qemu-utils}/libexec/qemu-bridge-helper";
       owner = "root";
       group = "root";
       capabilities = "cap_net_admin+ep";


### PR DESCRIPTION
diff on one of the servers where I deployed this:

```
alsa-lib: 1.2.11 → ∅, -1640.9 KiB
alsa-topology-conf: 1.2.5.1 → ∅, -336.1 KiB
alsa-ucm-conf: 1.2.11 → ∅, -523.9 KiB
avahi: 0.8 → ∅, -1543.4 KiB
bluez: 5.75 → ∅, -9339.4 KiB
cairo: 1.18.0 → ∅, -1678.5 KiB
capstone: 5.0.1 → ∅, -9841.1 KiB
cdparanoia-III: 10.2 → ∅, -356.2 KiB
celt: 0.11.3 → ∅, -168.4 KiB
dconf: 0.40.0 → ∅, -308.5 KiB
dejavu-fonts-minimal: 2.37 → ∅, -742.6 KiB
dtc: 1.7.0 → ∅, -502.6 KiB
ell: 0.64 → ∅, -610.0 KiB
fdk-aac: 2.0.3 → ∅, -1479.6 KiB
ffmpeg-headless: 6.1.1 → ∅, -26156.4 KiB
fftw-single: 3.3.10 → ∅, -4119.5 KiB
flac: 1.4.3 → ∅, -703.8 KiB
fontconfig: 2.15.0 → ∅, -2065.4 KiB
fribidi: 1.0.13 → ∅, -154.3 KiB
gdk-pixbuf: 2.42.11 → 2.42.12
graphite2: 1.3.14 → ∅, -219.6 KiB
gst-plugins-base: 1.24.2 → ∅, -7361.0 KiB
gstreamer: 1.24.2 → ∅, -5861.5 KiB
harfbuzz: 8.4.0 → ∅, -3133.7 KiB
hwdata: 0.382 → ∅, -9336.5 KiB
icu4c: 73.2 → ∅, -38593.5 KiB
initrd: ∅ → .keep
initrd-bin: ∅ → ε, +79.5 KiB
iso-codes: 4.16.0 → ∅, -19529.0 KiB
lame: 3.100 → ∅, -325.5 KiB
ldacBT: 2.0.2.3 → ∅, -88.7 KiB
libao: 1.2.2 → ∅, -119.4 KiB
libass: 0.17.1 → ∅, -225.5 KiB
libcacard: 2.8.1 → ∅, -133.5 KiB
libcamera: 0.2.0 → ∅, -2917.2 KiB
libdaemon: 0.14 → ∅, -36.9 KiB
libdatrie: 2019-12-20 → ∅, -42.2 KiB
libdrm: 2.4.120 → ∅, -535.0 KiB
libfreeaptx: 0.1.1 → ∅, -55.3 KiB
libical: 3.0.18 → ∅, -3920.3 KiB
libiscsi: 1.20.0 → ∅, -491.4 KiB
libjack2: 1.9.22 → ∅, -412.7 KiB
liblc3: 1.1.1 → ∅, -167.1 KiB
libmad: 0.15.1b → ∅, -138.6 KiB
libmpg123: 1.32.6 → ∅, -1055.3 KiB
libmysofa: 1.3.2 → ∅, -1354.2 KiB
libogg: 1.3.5 → ∅, -44.3 KiB
libopus: 1.5.2 → ∅, -435.6 KiB
libpciaccess: 0.18.1 → ∅, -66.9 KiB
libpulseaudio: 17.0 → ∅, -4880.5 KiB
libsamplerate: 0.2.2 → ∅, -1541.1 KiB
libslirp: 4.7.0 → ∅, -170.0 KiB
libsndfile: 1.2.2 → ∅, -592.0 KiB
libssh: 0.10.6 → ∅, -699.1 KiB
libthai: 0.1.29 → ∅, -627.2 KiB
libtheora: 1.1.1 → ∅, -740.0 KiB
libtool: 2.4.7 → ∅, -55.8 KiB
libusb: 1.0.27 → ∅, -146.7 KiB
libva-minimal: 2.21.0 → ∅, -225.9 KiB
libvisual: 0.4.1 → ∅, -366.6 KiB
libvorbis: 1.3.7 → ∅, -1080.8 KiB
libvpx: 1.14.0 → ∅, -8109.2 KiB
libyaml: 0.2.5 → ∅, -137.3 KiB
lilv: 0.24.24 → ∅, -372.3 KiB
lttng-ust: 2.13.8 → ∅, -1498.0 KiB
nspr: 4.35 → ∅, -337.8 KiB
nss: 3.90.2 → ∅, -3822.4 KiB
numactl: 2.0.18 → ∅, -248.9 KiB
openfec: 1.4.2.9 → ∅, -196.4 KiB
openssl: 3.0.13 → 3.0.14
opusfile: 0.12 → ∅, -116.6 KiB
orc: 0.4.38 → ∅, -859.5 KiB
pango: 1.52.2 → ∅, -803.7 KiB
pipewire: 1.0.6 → ∅, -12778.4 KiB
pixman: 0.43.4 → ∅, -802.9 KiB
qemu: 8.2.4 → ∅, -852939.0 KiB
qemu-utils: ∅ → 8.2.5, +40690.3 KiB
roc-toolkit: 0.3.0 → ∅, -5613.2 KiB
sbc: 2.0 → ∅, -256.2 KiB
serd: 0.30.16 → ∅, -140.9 KiB
snappy: 1.2.0 → ∅, -63.5 KiB
sord: 0.16.16 → ∅, -95.0 KiB
source: +260.6 KiB
sox-unstable: 2021-05-09 → ∅, -680.4 KiB
soxr: 0.1.3 → ∅, -298.4 KiB
speex: 1.2.1 → ∅, -121.6 KiB
speexdsp: 1.2.1 → ∅, -74.4 KiB
sratom: 0.6.16 → ∅, -47.1 KiB
srt: 1.5.3 → ∅, -6966.1 KiB
svt-av1: 2.0.0 → ∅, -10705.0 KiB
tremor-unstable: 2018-03-16 → ∅, -124.7 KiB
v4l-utils: 1.24.1 → ∅, -903.8 KiB
vde2: 2.3.3 → ∅, -693.2 KiB
wavpack: 5.7.0 → ∅, -501.4 KiB
webrtc-audio-processing: 1.3 → ∅, -1668.4 KiB
wolfssl-all: 5.7.0 → ∅, -4567.1 KiB
x264: 0-unstable-2023-10-01 → ∅, -2384.6 KiB
x265: 3.5 → ∅, -21494.4 KiB
xvidcore: 1.3.7 → ∅, -770.8 KiB
xz: 5.4.6 → 5.4.7, +9.0 KiB
zimg: 3.0.5 → ∅, -1039.7 KiB
zix: 0.4.2 → ∅, -134.2 KiB
```