### PR TITLE
cloud-hypervisor: allow using a capability wrapper

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -360,6 +360,13 @@ in
       capabilities = "cap_net_admin+ep";
     };
 
+    security.wrappers.cloud-hypervisor = lib.mkIf config.microvm.host.cloud-hypervisor.enable {
+      source = lib.getExe config.microvm.host.cloud-hypervisor.package;
+      owner = "root";
+      group = "root";
+      capabilities = "cap_net_admin+ep";
+    };
+
     # You must define this file with your bridge interfaces if you
     # intend to use qemu-bridge-helper through a `type = "bridge"`
     # interface.

--- a/nixos-modules/host/options.nix
+++ b/nixos-modules/host/options.nix
@@ -10,6 +10,11 @@
       '';
     };
 
+    host.cloud-hypervisor.enable = lib.mkEnableOption "Install a cloud-hypervisor security wrapper" // {
+      default = true;
+    };
+    host.cloud-hypervisor.package = lib.mkPackageOption pkgs "cloud-hypervisor" { };
+
     host.useNotifySockets = mkOption {
       type = types.bool;
       default = false;

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -436,6 +436,11 @@ in
       description = "Extra arguments to pass to cloud-hypervisor.";
     };
 
+    cloud-hypervisor.systemExecutable.enable =
+      mkEnableOption "Prefer cloud-hypervisor from PATH (e.g. a security wrapper)";
+    cloud-hypervisor.systemExecutable.versionCheck =
+      mkEnableOption "Ensure the system executable matches up to the minor version";
+
     crosvm.extraArgs = mkOption {
       type = with types; listOf str;
       default = [];


### PR DESCRIPTION
I'd like to be able to have cloud-hypervisor create TAP devices without sudo. I'm still testing this, and I'm not sure how best to handle the graphics/non-graphics variants and versions, but the basic functionality of trying a "system" cloud-hypervisor and falling back to the store path is easy to achieve