### PR TITLE
Use writeShellScript* to remove redundant shebang; Use absolute paths for virtiofsd;  Use supervisord to spawn virtiofsd processes instead of disowning them 

### DIFF
--- a/doc/src/faq.md
+++ b/doc/src/faq.md
@@ -64,9 +64,7 @@ does.
 environment.systemPackages = [ (
   # Provide a manual updating script that fetches the latest
   # updated+built system from Hydra
-  pkgs.writeScriptBin "update-microvm" ''
-    #! ${pkgs.runtimeShell} -e
-
+  pkgs.writeShellScriptBin "update-microvm" ''
     if [ $# -lt 1 ]; then
       NAMES="$(ls -1 /var/lib/microvms)"
     else

--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  inherit (pkgs) lib writeScriptBin;
+  inherit (pkgs) lib;
 
   inherit (import ./. { nixpkgs-lib = lib; }) createVolumesScript makeMacvtap;
   inherit (makeMacvtap {
@@ -23,9 +23,7 @@ let
   execArg = lib.optionalString microvmConfig.prettyProcnames
     ''-a "microvm@${microvmConfig.hostName}"'';
 
-  runScriptBin = pkgs.buildPackages.writeScriptBin "microvm-run" ''
-    #! ${pkgs.runtimeShell} -e
-
+  runScriptBin = pkgs.buildPackages.writeShellScriptBin "microvm-run" ''
     ${preStart}
     ${createVolumesScript pkgs.buildPackages microvmConfig.volumes}
     ${lib.optionalString (hypervisorConfig.requiresMacvtapAsFds or false) openMacvtapFds}
@@ -33,14 +31,12 @@ let
     exec ${execArg} ${command}
   '';
 
-  shutdownScriptBin = pkgs.buildPackages.writeScriptBin "microvm-shutdown" ''
-    #! ${pkgs.runtimeShell} -e
-
+  shutdownScriptBin = pkgs.buildPackages.writeShellScriptBin "microvm-shutdown" ''
     ${shutdownCommand}
   '';
 
-  balloonScriptBin = pkgs.buildPackages.writeScriptBin "microvm-balloon" ''
-    #! ${pkgs.runtimeShell} -e
+  balloonScriptBin = pkgs.buildPackages.writeShellScriptBin "microvm-balloon" ''
+    set -e
 
     if [ -z "$1" ]; then
       echo "Usage: $0 <balloon-size-mb>"

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -266,10 +266,10 @@ in
           SyslogIdentifier = "microvm-virtiofsd@%i";
           LimitNOFILE = 1048576;
         };
-        path = with pkgs; [ coreutils virtiofsd ];
+        path = with pkgs; [ virtiofsd ];
         script = ''
-          for d in current/share/microvm/virtiofs/*; do
-            SOCKET=$(cat $d/socket)
+          for d in $PWD/current/share/microvm/virtiofs/*; do
+            SOCKET="$(realpath "$(cat $d/socket)")"
             SOURCE="$(cat $d/source)"
             mkdir -p "$SOURCE"
 

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -137,9 +137,7 @@ in
           RemainAfterExit = true;
           ExecStop =
             let
-              stopScript = pkgs.writeScript "stop-microvm-tap-interfaces" ''
-                #! ${pkgs.runtimeShell} -e
-
+              stopScript = pkgs.writeShellScript "stop-microvm-tap-interfaces" ''
                 cd ${stateDir}/$1
                 for id in $(cat current/share/microvm/tap-interfaces); do
                   ${pkgs.iproute2}/bin/ip tuntap del name $id mode tap
@@ -176,8 +174,7 @@ in
           RemainAfterExit = true;
           ExecStop =
             let
-              stopScript = pkgs.writeScript "stop-microvm-tap-interfaces" ''
-                #! ${pkgs.runtimeShell} -e
+              stopScript = pkgs.writeShellScript "stop-microvm-tap-interfaces" ''
                 cd ${stateDir}/$1
                 cat current/share/microvm/macvtap-interfaces | while read -r line;do
                   opts=( $line )

--- a/nixos-modules/microvm/graphics.nix
+++ b/nixos-modules/microvm/graphics.nix
@@ -2,19 +2,16 @@
 
 let
   # TODO: did not get sommelier to work
-  run-sommelier = with pkgs; writeScriptBin "run-sommelier" ''
-    #!${runtimeShell} -e
-    exec ${sommelier}/bin/sommelier --virtgpu-channel -- $@
+  run-sommelier = with pkgs; writeShellScriptBin "run-sommelier" ''
+    exec ${lib.getExe sommelier} --virtgpu-channel -- $@
   '';
   # Working: run Wayland applications prefixed with `run-wayland-proxy`
-  run-wayland-proxy = with pkgs; writeScriptBin "run-wayland-proxy" ''
-    #!${runtimeShell} -e
-    exec ${wayland-proxy-virtwl}/bin/wayland-proxy-virtwl --virtio-gpu -- $@
+  run-wayland-proxy = with pkgs; writeShellScriptBin "run-wayland-proxy" ''
+    exec ${lib.getExe wayland-proxy-virtwl} --virtio-gpu -- $@
   '';
   # Waypipe. Needs `microvm#waypipe-client` on the host.
-  run-waypipe = with pkgs; writeScriptBin "run-waypipe" ''
-    #!${runtimeShell} -e
-    exec ${waypipe}/bin/waypipe --vsock -s 2:6000 server $@
+  run-waypipe = with pkgs; writeShellScriptBin "run-waypipe" ''
+    exec ${lib.getExe waypipe}/bin/waypipe --vsock -s 2:6000 server $@
   '';
 in
 lib.mkIf config.microvm.graphics.enable {

--- a/nixos-modules/microvm/ssh-deploy.nix
+++ b/nixos-modules/microvm/ssh-deploy.nix
@@ -94,7 +94,7 @@ in
 
   # Implementations
   config.microvm.deploy = {
-    installOnHost = pkgs.writeScriptBin "microvm-install-on-host" ''
+    installOnHost = pkgs.writeShellScriptBin "microvm-install-on-host" ''
       set -eou pipefail
 
       HOST="$1"
@@ -157,7 +157,7 @@ in
     '';
 
     sshSwitch = lib.mkIf canSwitchViaSsh (
-      pkgs.writeScriptBin "microvm-switch" ''
+      pkgs.writeShellScriptBin "microvm-switch" ''
         set -eou pipefail
 
         TARGET="$1"
@@ -186,7 +186,7 @@ in
       ''
     );
 
-    rebuild = with config.microvm.deploy; pkgs.writeScriptBin "microvm-rebuild" ''
+    rebuild = with config.microvm.deploy; pkgs.writeShellScriptBin "microvm-rebuild" ''
       set -eou pipefail
 
       HOST="$1"

--- a/pkgs/build-microvm.nix
+++ b/pkgs/build-microvm.nix
@@ -2,13 +2,11 @@
 # local pkgs not from the target flake.
 { self
 , lib, targetPlatform
-, writeScriptBin, runtimeShell
+, writeShellScriptBin
 , coreutils, git, nix
 }:
 
-writeScriptBin "build-microvm" ''
-  #! ${runtimeShell} -e
-
+writeShellScriptBin "build-microvm" ''
   PATH=${lib.makeBinPath [ coreutils git nix ]}
 
   if [ $# -lt 1 ]; then

--- a/pkgs/microvm-command.nix
+++ b/pkgs/microvm-command.nix
@@ -14,8 +14,7 @@ let
   };
   colored = color: text: "${colors.${color}}${text}${colors.normal}";
 in
-writeScriptBin "microvm" ''
-  #! ${pkgs.runtimeShell}
+writeShellScriptBin "microvm" ''
   set -e
 
   PATH=${lib.makeBinPath [


### PR DESCRIPTION
Tested on a real world none-declerative microvm setup.