### PR TITLE
Fix cross-compilation issue with runners

### DIFF
--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -23,7 +23,7 @@ let
   execArg = lib.optionalString microvmConfig.prettyProcnames
     ''-a "microvm@${microvmConfig.hostName}"'';
 
-  runScriptBin = pkgs.buildPackages.writeShellScriptBin "microvm-run" ''
+  runScriptBin = pkgs.writeShellScriptBin "microvm-run" ''
     ${preStart}
     ${createVolumesScript pkgs.buildPackages microvmConfig.volumes}
     ${lib.optionalString (hypervisorConfig.requiresMacvtapAsFds or false) openMacvtapFds}
@@ -31,11 +31,11 @@ let
     exec ${execArg} ${command}
   '';
 
-  shutdownScriptBin = pkgs.buildPackages.writeShellScriptBin "microvm-shutdown" ''
+  shutdownScriptBin = pkgs.writeShellScriptBin "microvm-shutdown" ''
     ${shutdownCommand}
   '';
 
-  balloonScriptBin = pkgs.buildPackages.writeShellScriptBin "microvm-balloon" ''
+  balloonScriptBin = pkgs.writeShellScriptBin "microvm-balloon" ''
     set -e
 
     if [ -z "$1" ]; then


### PR DESCRIPTION
[fixes #263]

```
$ cat /var/lib/microvms/net-vm/current/bin/microvm-run
#!/nix/store/q449kdcw4lay790zri7gilgjzbgrq9fv-bash-aarch64-unknown-linux-gnu-5.2p26/bin/bash
```


```
$ file /nix/store/q449kdcw4lay790zri7gilgjzbgrq9fv-bash-aarch64-unknown-linux-gnu-5.2p26/bin/bash
/nix/store/q449kdcw4lay790zri7gilgjzbgrq9fv-bash-aarch64-unknown-linux-gnu-5.2p26/bin/bash: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /nix/store/585wgmdaa952yyla33kffm733a8xbh32-glibc-aarch64-unknown-linux-gnu-2.39-52/lib/ld-linux-aarch64.so.1, BuildID[sha1]=87efdae73b275a3eb14444a2d0ff21771c486c3a, for GNU/Linux 3.10.0, not stripped
```

```
$ uname -a
Linux ghaf-host 5.10.120 #1-NixOS SMP Tue Jan 1 00:00:00 UTC 1980 aarch64 GNU/Linux
```