### PR TITLE
Fix quoting of virtiofs sources in supervisord config

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -297,7 +297,7 @@ in
           command=${lib.getExe pkgs.virtiofsd} \
           --socket-path=$SOCKET \
           --socket-group=${config.users.users.microvm.group} \
-          --shared-dir "$SOURCE" \
+          --shared-dir=\"$SOURCE\" \
           --rlimit-nofile ${toString serviceConfig.LimitNOFILE} \
           --thread-pool-size ${toString config.microvm.virtiofsd.threadPoolSize} \
           --posix-acl --xattr \


### PR DESCRIPTION
The quotes around `$SOURCE` need to be escaped, currently it breaks virtiofs sources which contain a space in the path.