### PR TITLE
Add option to disable notify support

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -99,7 +99,7 @@ in {
 
     # Ensure notify sockets are removed if cloud-hypervisor didn't exit cleanly the last time
     rm -f notify.vsock notify.vsock_8888
-
+  '' + lib.optionalString microvmConfig.notifySupport ''
     # Start socat to forward systemd notify socket over vsock
     if [ -n "$NOTIFY_SOCKET" ]; then
       ${pkgs.socat}/bin/socat UNIX-LISTEN:notify.vsock_8888,fork UNIX-SENDTO:$NOTIFY_SOCKET &
@@ -136,6 +136,7 @@ in {
         "--cmdline" "${kernelConsole} reboot=t panic=-1 ${toString microvmConfig.kernelParams}"
         "--seccomp" "true"
         "--memory" memOps
+      ] ++ lib.optionals microvmConfig.notifySupport [
         "--platform" "oem_strings=[io.systemd.credential:vmm.notify_socket=vsock-stream:2:8888]"
         "--vsock" "cid=3,socket=notify.vsock"
       ]

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -106,7 +106,8 @@ in
         restartTriggers = [guestConfig.system.build.toplevel];
         overrideStrategy = "asDropin";
         serviceConfig.Type =
-          if guestConfig.microvm.declaredRunner.supportsNotifySocket
+          if guestConfig.microvm.declaredRunner.supportsNotifySocket &&
+            microvmConfig.notifySupport
           then "notify"
           else "simple";
       };

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -56,6 +56,18 @@ in
       type = with types; nullOr str;
     };
 
+    notifySupport = mkOption {
+      description = ''
+        Whether to enable systemd notify support if the hypervisor supports it.
+
+        Presumably when mixing different systemd versions on the host and in the
+        microvm with significant enough changes between them the notify support
+        breaks and the microvm might be stuck in initrd.
+      '';
+      default = true;
+      type = types.bool;
+    };
+
     kernel = mkOption {
       description = "Kernel package to use for MicroVM runners";
       default = config.boot.kernelPackages.kernel;


### PR DESCRIPTION
Presumable when mixing systemd 255 on the host and 256 in the microvm the notify support breaks and the VM doesn't start anymore.