### PR TITLE
support unmounted volumes

### DIFF
--- a/nixos-modules/microvm/mounts.nix
+++ b/nixos-modules/microvm/mounts.nix
@@ -110,7 +110,7 @@ lib.mkIf config.microvm.guest.enable {
       }) {} (withDriveLetters config.microvm)
   ) (
     # 9p/virtiofs Shares
-    builtins.foldl' (result: { mountPoint, tag, proto, source, ... }: result // {
+    builtins.foldl' (result: { mountPoint, tag, proto, source, ... }: result // lib.optionalAttrs (mountPoint != null) {
       "${mountPoint}" = {
         device = tag;
         fsType = proto;


### PR DESCRIPTION
Fixes/implements https://github.com/astro/microvm.nix/issues/273

Allow for a block device from the host to be accessible in the guest without mounting it as a filesystem in the guest.
