### PR TITLE
doc: fix literalExpression in examples

### DIFF
--- a/nixos-modules/host/options.nix
+++ b/nixos-modules/host/options.nix
@@ -32,15 +32,17 @@
         at all, just set
         `systemd.services."microvm-tap-interfaces@%i.service".enable = false`
       '';
-      example = ''
+      example = lib.literalExpression ''
         # Attach tap interface to bridge br0, and bring it up
-        ''${pkgs.iproute2}/bin/ip link set "$id" master br0 up
+        "${pkgs.iproute2}/bin/ip link set \"$id\" master br0 up"
       '';
       type = types.lines;
       default = ''
         ${pkgs.iproute2}/bin/ip link set "$id" up
       '';
-      defaultText = "''${pkgs.iproute2}/bin/ip link set \"$id\" up";
+      defaultText = ''
+        ${pkgs.iproute2}/bin/ip link set "$id" up
+      '';
     };
 
     vms = mkOption {

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -148,8 +148,7 @@ in
           };
         });
       default = [];
-      example = lib.literalExpression
-        ''
+      example = lib.literalExpression /* nix */ ''
         [ # forward local port 2222 -> 22, to ssh into the VM
           { from = "host"; host.port = 2222; guest.port = 22; }
 
@@ -159,7 +158,7 @@ in
             host.address = "127.0.0.1"; host.port = 80;
           }
         ]
-        '';
+      '';
       description =
         ''
           When using the SLiRP user networking (default), this option allows to
@@ -319,17 +318,19 @@ in
     devices = mkOption {
       description = "PCI/USB devices that are passed from the host to the MicroVM";
       default = [];
-      example = literalExpression ''[ {
-        bus = "pci";
-        path = "0000:01:00.0";
-      } {
-        bus = "pci";
-        path = "0000:01:01.0";
-      } {
-        # QEMU only
-        bus = "usb";
-        path = "vendorid=0xabcd,productid=0x0123";
-      } ]'';
+      example = literalExpression /* nix */ ''
+        [ {
+          bus = "pci";
+          path = "0000:01:00.0";
+        } {
+          bus = "pci";
+          path = "0000:01:01.0";
+        } {
+          # QEMU only
+          bus = "usb";
+          path = "vendorid=0xabcd,productid=0x0123";
+        } ]
+      '';
       type = with types; listOf (submodule {
         options = {
           bus = mkOption {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/dacc5154-84a6-4c75-8c7a-2f04fefe5057)


After:
![image](https://github.com/user-attachments/assets/ee32e76d-aeec-4804-829d-82d19fb09ebd)

