### PR TITLE
Add direct and serial options to disk devices

### DIFF
--- a/lib/runners/alioth.nix
+++ b/lib/runners/alioth.nix
@@ -29,7 +29,13 @@ in {
         "--blk" (lib.escapeShellArg "path=${storeDisk},readonly=true")
       ]
       ++
-      builtins.concatMap ({ image, ... }:
+      builtins.concatMap ({ image, serial, direct, ... }:
+        lib.warnIf (serial != null) ''
+          Volume serial is not supported for alioth
+        ''
+        lib.warnIf direct ''
+          Volume direct IO is not supported for alioth
+        ''
         [ "--blk" (lib.escapeShellArg image) ]
       ) volumes
       ++

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -92,8 +92,14 @@ in {
         "-s" socket
       ]
       ++
-      builtins.concatMap ({ image, ... }:
-        [ "--rwdisk" image ]
+      builtins.concatMap ({ image, direct, serial, ... }:
+        [ "--block"
+          "${image},o_direct=${
+            if direct then "true" else "false"
+          }${
+            lib.optionalString (serial != null) ",id=${serial}"
+          }"
+        ]
       ) volumes
       ++
       builtins.concatMap ({ proto, tag, source, ... }:

--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -37,13 +37,19 @@ let
       is_root_device = false;
       is_read_only = true;
       io_engine = "Async";
-    } ] ++ map ({ image, ... }: {
-      drive_id = image;
-      path_on_host = image;
-      is_root_device = false;
-      is_read_only = false;
-      io_engine = "Async";
-    }) volumes;
+    } ] ++ map ({ image, serial, direct, ... }:
+      lib.warnIf (serial != null) ''
+        Volume serial is not supported for firecracker
+      ''
+      lib.warnIf direct ''
+        Volume direct IO is not supported for firecracker
+      '' {
+        drive_id = image;
+        path_on_host = image;
+        is_root_device = false;
+        is_read_only = false;
+        io_engine = "Async";
+      }) volumes;
     network-interfaces = map ({ type, id, mac, ... }:
       if type == "tap"
       then {

--- a/lib/runners/kvmtool.nix
+++ b/lib/runners/kvmtool.nix
@@ -38,8 +38,15 @@ in {
       ++
       lib.optionals (balloonMem > 0) [ "--balloon" ]
       ++
-      builtins.concatMap ({ image, ... }:
-        [ "-d" (lib.escapeShellArg image) ]
+      builtins.concatMap ({ image, serial, direct, ... }:
+        lib.warnIf (serial != null) ''
+          Volume serial is not supported for kvmtool
+        ''
+        [ "-d"
+          (lib.escapeShellArg "image${
+            lib.optionalString direct ",direct"
+          }")
+        ]
       ) volumes
       ++
       builtins.concatMap ({ proto, source, tag, ... }:

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -208,8 +208,16 @@ lib.warnIf (mem == 2048) ''
     lib.optionals (user != null) [ "-user" user ] ++
     lib.optionals (socket != null) [ "-qmp" "unix:${socket},server,nowait" ] ++
     lib.optionals (balloonMem > 0) [ "-device" "virtio-balloon" ] ++
-    builtins.concatMap ({ image, letter, ... }:
-      [ "-drive" "id=vd${letter},format=raw,file=${image},if=none,aio=io_uring,discard=unmap" "-device" "virtio-blk-${devType},drive=vd${letter}" ]
+    builtins.concatMap ({ image, letter, serial, direct, ... }:
+      [ "-drive"
+        "id=vd${letter},format=raw,file=${image},if=none,aio=io_uring,discard=unmap${
+          lib.optionalString (direct != null) ",cache=none"
+        }"
+        "-device"
+        "virtio-blk-${devType},drive=vd${letter}${
+          lib.optionalString (serial != null) ",serial=${serial}"
+        }"
+      ]
     ) volumes ++
     lib.optionals (shares != []) (
       [

--- a/lib/runners/stratovirt.nix
+++ b/lib/runners/stratovirt.nix
@@ -89,9 +89,11 @@ in {
       "-device" "virtio-blk-${devType 2},drive=store,id=blk_store"
     ] ++
     lib.optionals (socket != null) [ "-qmp" "unix:${socket},server,nowait" ] ++
-    builtins.concatMap ({ image, letter, ... }: [
-      "-drive" "id=vd${letter},format=raw,file=${image},aio=io_uring,direct=false"
-      "-device" "virtio-blk-${devType 4},drive=vd${letter},id=blk_vd${letter}"
+    builtins.concatMap ({ image, letter, serial, direct, ... }: [
+      "-drive" "id=vd${letter},format=raw,file=${image},aio=io_uring,direct=${if direct then "on" else "off"}"
+      "-device" "virtio-blk-${devType 4},drive=vd${letter},id=blk_vd${letter}${
+        lib.optionalString (serial != null) ",serial=${serial}"
+      }"
     ]) volumes ++
     lib.optionals (shares != []) (
       builtins.concatMap ({ proto, index, socket, source, tag, ... }: {

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -185,6 +185,18 @@ in
             type = str;
             description = "Path to disk image on the host";
           };
+          serial = mkOption {
+            type = nullOr str;
+            default = null;
+            description = "User-configured serial number for the disk
+            (Currently only respected if using cloud-hypervisor)";
+          };
+          direct = mkOption {
+            type = nullOr bool;
+            default = null;
+            description = "Whether to set O_DIRECT on the disk.
+            (Currently only respected if using cloud-hypervisor)";
+          };
           label = mkOption {
             type = nullOr str;
             default = null;


### PR DESCRIPTION
I only added support for cloud-hypervisor. The options are also supported in qemu (and possibly others) but i am just using cloud hypervisor.

serial is not documented yet, but it's been supported by cloud hypervisor for a year.

One thing to watch out for is the length of serial, it has to be 20 characters (or less, maybe).

Direct does not improve I/O performance per se, it mostly reduces overhead and makes VMs less noisy (O_DIRECT).

Maybe this PR should be closed wihout merging and we should have a manual way (i.e. a blanket "extraOpts" option) to specify hypervisor specific options because the doesn't pattern doesnt seem sustainable.

I am not using linux and I didn't want to spend time on setting up the formatter for nix (I am usually using nixfmt in my flake). So if you would like to fix formatting please rebase and format.