### PR TITLE
fix macvtaps

### DIFF
--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -63,7 +63,6 @@ pkgs.buildPackages.runCommand "microvm-${microvmConfig.hypervisor}-${hostName}"
   passthru = {
     inherit canShutdown supportsNotifySocket tapMultiQueue;
     inherit (microvmConfig) hypervisor;
-    inherit (hypervisorConfig) tapMultiQueue;
   };
 } ''
   mkdir -p $out/bin

--- a/nixos-modules/microvm/interfaces.nix
+++ b/nixos-modules/microvm/interfaces.nix
@@ -53,11 +53,11 @@ in
         ${pkgs.coreutils-full}/bin/chown '${user}:${group}' /dev/tap$(< "/sys/class/net/${id}/ifindex")
       '') macvtapInterfaces;
 
-      macvap-down = pkgs.writeShellScriptBin "microvm-${hostName}-macvtap-down" (''
+      macvtap-down = ''
         set -ou pipefail
-      '' + lib.concatMapStrings ({ id, mac, ... }: ''
+      '' + lib.concatMapStrings ({ id, ... }: ''
         ${pkgs.iproute2}/bin/ip link del name '${id}'
-      '') macvtapInterfaces);
+      '') macvtapInterfaces;
     }
   ) ];
 }


### PR DESCRIPTION
#291 introduced two bugs related to macvtaps:
- multiple definition of `tapMultiQueue` in the passthru attributes.
I'm guessing the on I removed shouldn't be there as it's just the other one without
the default case.
- wrong type of `binScripts.macvtap-down`