### PR TITLE
fix: macvtap mode syntax

### DIFF
--- a/nixos-modules/microvm/interfaces.nix
+++ b/nixos-modules/microvm/interfaces.nix
@@ -46,7 +46,7 @@ in
         if [ -e /sys/class/net/${id} ]; then
           ${pkgs.iproute2}/bin/ip link delete '${id}'
         fi
-        ${pkgs.iproute2}/bin/ip link add link '${macvtap.link}' name '${id}' address '${mac}' type macvtap '${macvtap.mode}'
+        ${pkgs.iproute2}/bin/ip link add link '${macvtap.link}' name '${id}' address '${mac}' type macvtap mode '${macvtap.mode}'
         ${pkgs.iproute2}/bin/ip link set '${id}' allmulticast on
         echo 1 > "/proc/sys/net/ipv6/conf/${id}/disable_ipv6"
         ${pkgs.iproute2}/bin/ip link set '${id}' up


### PR DESCRIPTION
Found runtime bug for macvtaps. They explicitely need the keyword `mode`.
