### PR TITLE
fix: only disable IPv6 when present

### DIFF
--- a/nixos-modules/microvm/interfaces.nix
+++ b/nixos-modules/microvm/interfaces.nix
@@ -48,7 +48,9 @@ in
         fi
         ${pkgs.iproute2}/bin/ip link add link '${macvtap.link}' name '${id}' address '${mac}' type macvtap mode '${macvtap.mode}'
         ${pkgs.iproute2}/bin/ip link set '${id}' allmulticast on
-        echo 1 > "/proc/sys/net/ipv6/conf/${id}/disable_ipv6"
+        if [ -f "/proc/sys/net/ipv6/conf/${id}/disable_ipv6" ]; then
+          echo 1 > "/proc/sys/net/ipv6/conf/${id}/disable_ipv6"
+        fi
         ${pkgs.iproute2}/bin/ip link set '${id}' up
         ${pkgs.coreutils-full}/bin/chown '${user}:${group}' /dev/tap$(< "/sys/class/net/${id}/ifindex")
       '') macvtapInterfaces;


### PR DESCRIPTION
When the host has IPv6 disabled via "ipv6.disable=1" completely the service to setup up a macvtap interface fails because it tries to write to the nonexistant "/proc/sys/net/ipv6" directory. Fix this by checking for its presence first.