### PR TITLE
WIP: qemu: randomly choose vsock port on the host side

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -147,6 +147,7 @@ let
     else "";
 
   supportsNotifySocket = vsock.cid != null;
+  vsockHostPortOffset = 600000;
 
 in
 lib.warnIf (mem == 2048) ''
@@ -163,15 +164,11 @@ lib.warnIf (mem == 2048) ''
     # Clean up temporary files.
     ${pkgs.coreutils}/bin/rm -f ./socat.log ./notify_socket.cred
     # Default value: for running without systemd.
-    NOTIFY_VSOCK_PORT=8888
+    NOTIFY_VSOCK_PORT=${toString (vsockHostPortOffset + vsock.cid)}
     # Start socat to forward systemd notify socket over vsock
     if [ -n "''${NOTIFY_SOCKET-}" ]; then
-        ${pkgs.socat}/bin/socat -d -d VSOCK-LISTEN:-1,fork UNIX-SENDTO:$NOTIFY_SOCKET 2> ./socat.log &
-        NOTIFY_VSOCK_PORT=$({ ${pkgs.coreutils}/bin/tail -f ./socat.log || true; } | ${pkgs.gawk}/bin/awk '/listening on/ { if (match($0, /port:[0-9]*/)) { print substr($0, RSTART + 5, RLENGTH - 5); exit; } }')
-        echo "Picked port for notify vsock: $NOTIFY_VSOCK_PORT"
+        ${pkgs.socat}/bin/socat -d -d VSOCK-LISTEN:$NOTIFY_VSOCK_PORT,fork UNIX-SENDTO:$NOTIFY_SOCKET 2> ./socat.log &
     fi
-    echo -n "vsock-stream:2:$NOTIFY_VSOCK_PORT" > ./notify_socket.cred
-
   '';
 
   command = lib.escapeShellArgs (
@@ -322,7 +319,7 @@ lib.warnIf (mem == 2048) ''
       # tried, SMBIOS Type 11 entries simply don't work. It looks like it might
       # be broken on QEMU side. Why? I don't know.
       "-fw_cfg"
-      "name=opt/io.systemd.credentials/vmm.notify_socket,file=./notify_socket.cred"
+      "name=opt/io.systemd.credentials/vmm.notify_socket,string=vsock-stream:2:${toString (vsockHostPortOffset + vsock.cid)}"
     ]
     ++
     extraArgs


### PR DESCRIPTION
Prevents conflicts between MicroVMs.

Somehow doesn't work first try; VM might timeout a few times before it starts working. The problem is most likely between socat and systemd. More debug logging is needed. (Adding it here would be trivial, actually.)