### PR TITLE
feat: Auto-initialize the host paths of shares

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -94,7 +94,14 @@ in
                     then updateFlake
                     else flake}' > flake
             chown -h ${user}:${group} flake
-          '';
+          ''
+          # Make sure that the sources of the shares can be accessed.
+          # Also ignore failures of each command for now
+          + builtins.foldl' (acc: share: acc + ''
+            # Initialize permissions for share with mountPoint ${share.mountPoint}
+            mkdir -p '${share.source}' || :
+            chown -hR ${user}:${group} '${share.source}' || :
+          '') "" guestConfig.microvm.shares;
         serviceConfig.SyslogIdentifier = "install-microvm-${name}";
       };
       "microvm@${name}" = {

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -97,7 +97,8 @@ in
           ''
           # Make sure that the sources of the shares can be accessed.
           # Also ignore failures of each command for now
-          + builtins.foldl' (acc: share: acc + ''
+          + builtins.foldl' (acc: share:
+            acc + lib.optionalString (share.source != "/nix/store") ''
             # Initialize permissions for share with mountPoint ${share.mountPoint}
             mkdir -p '${share.source}' || :
             chown -hR ${user}:${group} '${share.source}' || :

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -99,9 +99,9 @@ in
           # Also ignore failures of each command for now
           + builtins.foldl' (acc: share:
             acc + lib.optionalString (share.source != "/nix/store") ''
-            # Initialize permissions for share with mountPoint ${share.mountPoint}
-            mkdir -p '${share.source}' || :
-            chown -hR ${user}:${group} '${share.source}' || :
+              # Initialize permissions for share with mountPoint ${share.mountPoint}
+              mkdir -p '${share.source}' || :
+              chown -hR ${user}:${group} '${share.source}' || :
           '') "" guestConfig.microvm.shares;
         serviceConfig.SyslogIdentifier = "install-microvm-${name}";
       };


### PR DESCRIPTION
Hi, thanks for this amazing project!
I wanted to share a little patch here and hear your opinion if you want to add this kind of feature. I'm looking forward to your feedback!

### Motivation
- Currently microvms will fail if they have a share which doesn't yet exist on the host.
- If some permissions in the share are not accessible to the `microvm:kvm` user they will not be accessible for the guest, leading to somewhat surprising errors.
- I don't want to manually create the shares and ensure they have proper permissions
  - e.g. with this approach I can mount runtime secrets into a VM and have them readable without adding an additional script in my config

### Proposed change
- The `install-microvm-...` unit creates the directories for shares on the host.
- The `install-microvm-...` unit recursively chowns the directories for the configured runner user.
- Both changes only apply to fully declarative VMs.

### Issues / TODO
- There may be some cases where `mkdir` is not the desired way to create the share source directories, e.g. if one wants to mount a zfs dataset or btrfs subvolume in the location.
- There's a risk of permissions of already existing shares being lost. => We could also only initialize the permissions if the directory was newly created by install-microvm