### PR TITLE
fix(options): undefined variable 'kernelAtLeast'

### DIFF
--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -5,7 +5,7 @@ let
   };
 
   hostName = config.networking.hostName or "$HOSTNAME";
-
+  kernelAtLeast = lib.versionAtLeast config.boot.kernelPackages.kernel.version;
 in
 {
   options.microvm = with lib; {


### PR DESCRIPTION
It was slightly overlooked in last refactor.