### PR TITLE
Fixed the missing reference to kernelAtLeast for erofs

### DIFF
--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -3,6 +3,7 @@ let
   self-lib = import ../../lib {
     inherit lib;
   };
+  kernelAtLeast = lib.versionAtLeast config.boot.kernelPackages.kernel.version;
 
   hostName = config.networking.hostName or "$HOSTNAME";
 

--- a/nixos-modules/microvm/store-disk.nix
+++ b/nixos-modules/microvm/store-disk.nix
@@ -5,8 +5,6 @@ let
     rootPaths = [ config.system.build.toplevel ];
   };
 
-  kernelAtLeast = lib.versionAtLeast config.boot.kernelPackages.kernel.version;
-
   erofs-utils =
     # Are any extended options specified?
     if lib.any (with lib; flip elem ["-Ededupe" "-Efragments"]) config.microvm.storeDiskErofsFlags


### PR DESCRIPTION
Fixed a bug where `nixos-modules.options.nix` did not have a reference for `kernelAtLeast`, which was instead present in `nixos-modules.store-disk.nix`, where it wasn't needed.  It had only seemed to affect `erofs` volumes, where the reference was needed.