### PR TITLE
qemu: add deviceExtraArgs option for devices

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -290,9 +290,12 @@ lib.warnIf (mem == 2048) ''
       "-device" "qemu-xhci"
     ]
     ++
-    builtins.concatMap ({ bus, path, ... }: {
+    builtins.concatMap ({ bus, path, qemu,... }: {
       pci = [
-        "-device" "vfio-pci,host=${path},multifunction=on"
+        "-device" "vfio-pci,host=${path},multifunction=on${
+          # Allow to pass additional arguments to pci device
+          lib.optionalString (qemu.deviceExtraArgs != null) ",${qemu.deviceExtraArgs}"
+        }"
       ];
       usb = [
         "-device" "usb-host,${path}"

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -352,6 +352,7 @@ in
         } {
           bus = "pci";
           path = "0000:01:01.0";
+          deviceExtraArgs = "id=hostId,x-igd-opregion=on";
         } {
           # QEMU only
           bus = "usb";
@@ -370,6 +371,13 @@ in
             type = str;
             description = ''
               Identification of the device on its bus
+            '';
+          };
+          qemu.deviceExtraArgs = mkOption {
+            type =  with types; nullOr str;
+            default = null;
+            description = ''
+              Device additional arguments (optional)
             '';
           };
         };


### PR DESCRIPTION
This option could be useful in case we may need to pass any extra arguments to pci device.
For example:
`-device vfio-pci,host=x,multifunction=on,id=hostId,x-igd-opregion=on`
