### PR TITLE
fix: evaluation wont fail when BalloonMemory is enabled

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -52,12 +52,14 @@ let
     hugepages = "on";
   });
 
-  balloonOps = opsMapped {
+  balloonOps = opsMapped ({
     size = "${toString balloonMem}M";
     free_page_reporting = "on";
-  } // lib.optionalAttrs deflateOnOOM {
+  }
+  # enable deflating memory balloon on out-of-memory
+  // lib.optionals deflateOnOOM {
     deflate_on_oom = "on";
-  };
+  });
 
   tapMultiQueue = vcpu > 1;
 


### PR DESCRIPTION
When BalloonMemory was not 0 evaluation of derivations failed after PR #324 made deflate-on-oom optional.
The new optional set containing the argument was only merged with the other arguments, after those were converted into a list leading to a type mismatch.

fixes: #326