### PR TITLE
fix: replace deprecated hardware.opengl.enable

### DIFF
--- a/examples/graphics.nix
+++ b/examples/graphics.nix
@@ -69,7 +69,7 @@ nixpkgs.lib.nixosSystem {
           package != ""
         ) (lib.splitString " " packages));
 
-      hardware.opengl.enable = true;
+      hardware.graphics.enable = true;
     })
   ];
 }

--- a/examples/qemu-vnc.nix
+++ b/examples/qemu-vnc.nix
@@ -58,7 +58,7 @@ nixpkgs.lib.nixosSystem {
         displayManager.autoLogin.user = "user";
       };
 
-      hardware.opengl.enable = true;
+      hardware.graphics.enable = true;
 
       environment.systemPackages = with pkgs; [
         xdg-utils # Required


### PR DESCRIPTION
replace deprecated hardware.opengl.enable with hardware.graphics.enable

removes warning: The option `hardware.opengl.enable' defined in `/nix/store/...-source/flake.nix' has been renamed to `hardware.graphics.enable'.