### PR TITLE
cloud-hypervisor: use absolute paths for sockets

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -230,7 +230,7 @@ in {
     then ''
         api() {
           ${pkgs.curl}/bin/curl -s \
-            --unix-socket ${socket} \
+            --unix-socket $(realpath -L "$(dirname $0)/../../${socket}") \
             $@
         }
 
@@ -252,7 +252,7 @@ in {
   setBalloonScript =
     if socket != null
     then ''
-      ${pkgs.cloud-hypervisor}/bin/ch-remote --api-socket ${socket} resize --balloon $SIZE"M"
+      ${pkgs.cloud-hypervisor}/bin/ch-remote --api-socket $(realpath -L "$(dirname $0)/../../${socket}") resize --balloon $SIZE"M"
     ''
     else null;
 


### PR DESCRIPTION
so that scripts can be executed from anywhere