### PR TITLE
cloud-hypervisor: fix pci device config

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -215,7 +215,7 @@ in {
         else throw "Unsupported interface type ${type} for Cloud-Hypervisor"
       ) interfaces)
       ++
-      arg "--device" (map ({ bus, path }: {
+      arg "--device" (map ({ bus, path, ... }: {
         pci = "path=/sys/bus/pci/devices/${path}";
         usb = throw "USB passthrough is not supported on cloud-hypervisor";
       }.${bus}) devices)


### PR DESCRIPTION
bcabdfff46d3bb7806e6e358982ad457ee650fb7 (#325) indroduced additional device arguments, which were not handled by the cloud-hypervisor implementation