### PR TITLE
feat: Add `microvm.credentialFiles` for passing credentials to guests

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -39,7 +39,7 @@ let
   qemu = overrideQemu (if microvmConfig.cpu == null then
     pkgs.qemu_kvm else pkgs.buildPackages.qemu_full);
 
-  inherit (microvmConfig) hostName cpu vcpu mem balloonMem deflateOnOOM user interfaces shares socket forwardPorts devices vsock graphics storeOnDisk kernel initrdPath storeDisk;
+  inherit (microvmConfig) hostName cpu vcpu mem balloonMem deflateOnOOM user interfaces shares socket forwardPorts devices vsock graphics storeOnDisk kernel initrdPath storeDisk credentialFiles;
   inherit (microvmConfig.qemu) machine extraArgs serialConsole;
 
   inherit (import ../. { inherit (pkgs) lib; }) withDriveLetters;
@@ -146,6 +146,8 @@ let
     then "console=ttyAMA0"
     else "";
 
+  systemdCredentialStrings = lib.mapAttrsToList (name: path: "name=opt/io.systemd.credentials/${name},file=${path}" ) credentialFiles;
+  fwCfgOptions = systemdCredentialStrings;
 
 in
 lib.warnIf (mem == 2048) ''
@@ -172,6 +174,9 @@ lib.warnIf (mem == 2048) ''
 
       "-chardev" "stdio,id=stdio,signal=off"
       "-device" "virtio-rng-${devType}"
+    ] ++
+    lib.optionals (fwCfgOptions != [])  [
+      "-fw_cfg" (lib.concatStringsSep "," fwCfgOptions)
     ] ++
     lib.optionals serialConsole [
       "-serial" "chardev:stdio"

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -602,6 +602,18 @@ in
       description = "Flags to pass to gensquashfs";
       default = [ "-c" "zstd" "-j" "$NIX_BUILD_CORES" ];
     };
+
+    credentialFiles = mkOption {
+      type = with types; attrsOf path;
+      description = ''
+        Key-value pairs of credential files that will be loaded into the vm using systemd's io.systemd.credential feature.
+      '';
+      example = literalExpression /* nix */ ''
+        {
+          SOPS_AGE_KEY = "/run/secrets/guest_microvm_age_key";
+        }
+      '';
+    };
   };
 
   config = lib.mkMerge [ {


### PR DESCRIPTION
This commit implements `microvm.credentialFiles` a mechanism for passing
credentials into guest vms from the host.

Currently only support for qemu is implemented as I want to test the waters to
see if you're interested in this feature, Astro.

In addition to qmeu cloud-hypervisor can be supported via smbios. But it depends
on [this feature being added](https://github.com/cloud-hypervisor/cloud-hypervisor/issues/6951#issuecomment-2664967013), and also #336 being merged to microvm.nix

cloud-hypervisor could be supported immediately, but then the secrets would be
visible in the ps output.

A cursory code search shows that the following additional hypervisors could be
supported:

- crosvm: via fw_cfg, or smbios
- alioth: via fw_cfg
- stratovirt: via fw_cfg (maybe smbios)

kvmtool and firecracker both seem like they cannot be supported.

Related:
- #259
- #52
