### PR TITLE
fix: use target architecture binaries for disk volume creation

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -55,7 +55,7 @@ rec {
               then lib.escapeShellArgs mkfsExtraArgs
               else " ";
       in (lib.optionalString autoCreate ''
-      PATH=$PATH:${with pkgs.buildPackages; lib.makeBinPath [ coreutils util-linux e2fsprogs xfsprogs dosfstools btrfs-progs ]}
+      PATH=$PATH:${with pkgs; lib.makeBinPath [ coreutils util-linux e2fsprogs xfsprogs dosfstools btrfs-progs ]}
 
       if [ ! -e '${image}' ]; then
         touch '${image}'

--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -30,7 +30,7 @@ let
     microvm-run = ''
       set -eou pipefail
       ${preStart}
-      ${createVolumesScript pkgs.buildPackages microvmConfig.volumes}
+      ${createVolumesScript pkgs microvmConfig.volumes}
       ${lib.optionalString (hypervisorConfig.requiresMacvtapAsFds or false) openMacvtapFds}
 
       exec ${execArg} ${command}


### PR DESCRIPTION
Use pkgs instead of pkgs.buildPackages to ensure e2fsprogs and other utilities are built for the target ARM64 architecture rather than the build x86 architecture. This resolves the "Exec format error" when running chattr and mkfs.ext4.