### PR TITLE
Allow to discard all toplevel references when using erofs

### DIFF
--- a/doc/src/conventions.md
+++ b/doc/src/conventions.md
@@ -14,7 +14,7 @@ MicroVM deployments using the information on this page.
 | `microvm.devices.*.path`     | `share/microvm/pci-devices`            | `microvm-pci-devices@.service`      | PCI devices that must be bound to the **vfio-pci** driver on the host                         |
 | `microvm.shares.*.source`    | `share/microvm/virtiofs/${tag}/source` | `microvm-virtiofsd@.service`        | Source directory of a **virtiofs** instance by tag                                            |
 | `microvm.shares.*.socket`    | `share/microvm/virtiofs/${tag}/socket` | `microvm-virtiofsd@.service`        | **virtiofsd** socket path by tag                                                              |
-|                              | `share/microvm/system`                 |                                     | `config.system.build.toplevel` symlink, used for comparing versions when running `microvm -l` |
+| `microvm.systemSymlink`      | `share/microvm/system`                 |                                     | `config.system.build.toplevel` symlink, used for comparing versions when running `microvm -l` |
 
 
 ## Generating custom operating system hypervisor packages

--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -6,7 +6,7 @@
 let
   inherit (pkgs) lib;
 
-  inherit (microvmConfig) hostName virtiofsdScripts;
+  inherit (microvmConfig) hostName;
 
   inherit (import ./. { inherit lib; }) createVolumesScript makeMacvtap;
   inherit (makeMacvtap {

--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -72,7 +72,9 @@ pkgs.buildPackages.runCommand "microvm-${microvmConfig.hypervisor}-${hostName}"
   '') (builtins.attrNames binScriptPkgs)}
 
   mkdir -p $out/share/microvm
+  ${lib.optionalString microvmConfig.systemSymlink ''
   ln -s ${toplevel} $out/share/microvm/system
+  ''}
 
   echo vnet_hdr > $out/share/microvm/tap-flags
   ${lib.optionalString tapMultiQueue ''

--- a/lib/runners/alioth.nix
+++ b/lib/runners/alioth.nix
@@ -21,7 +21,7 @@ in {
         "--num-cpu" (toString vcpu)
         "-k" (lib.escapeShellArg "${kernel}/${pkgs.stdenv.hostPlatform.linux-kernel.target}")
         "-i" initrdPath
-        "-c" (lib.escapeShellArg "console=ttyS0 reboot=k panic=1 ${toString microvmConfig.kernelParams}")
+        "-c" (lib.escapeShellArg "console=ttyS0 reboot=k panic=1 ${builtins.unsafeDiscardStringContext (toString microvmConfig.kernelParams)}")
         "--entropy"
       ]
       ++

--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -144,7 +144,7 @@ in {
         "--serial" "tty"
         "--kernel" kernelPath
         "--initramfs" initrdPath
-        "--cmdline" "${kernelConsole} reboot=t panic=-1 ${toString microvmConfig.kernelParams}"
+        "--cmdline" "${kernelConsole} reboot=t panic=-1 ${builtins.unsafeDiscardStringContext (toString microvmConfig.kernelParams)}"
         "--seccomp" "true"
         "--memory" memOps
       ]

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -4,7 +4,8 @@
 }:
 
 let
-  inherit (pkgs) lib system;
+  inherit (pkgs) lib;
+  inherit (pkgs.stdenv) system;
   inherit (microvmConfig)
     vcpu mem balloonMem user interfaces volumes shares
     socket devices vsock graphics

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -52,7 +52,7 @@ in {
         "-m" (toString (mem + balloonMem))
         "-c" (toString vcpu)
         "--serial" "type=stdout,console=true,stdin=true"
-        "-p" "console=ttyS0 reboot=k panic=1 ${toString microvmConfig.kernelParams}"
+        "-p" "console=ttyS0 reboot=k panic=1 ${builtins.unsafeDiscardStringContext (toString microvmConfig.kernelParams)}"
       ]
       ++
       lib.optionals storeOnDisk [

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -7,26 +7,10 @@ let
   inherit (pkgs) lib;
   inherit (pkgs.stdenv) system;
   inherit (microvmConfig)
-    vcpu mem balloonMem user interfaces volumes shares
+    vcpu mem balloonMem user volumes shares
     socket devices vsock graphics
     kernel initrdPath storeDisk storeOnDisk;
   inherit (microvmConfig.crosvm) pivotRoot extraArgs;
-
-  inherit (macvtapFds) nextFreeFd;
-  inherit ((
-    builtins.foldl' ({ interfaceFds, nextFreeFd }: { type, id, ... }:
-      if type == "tap"
-      then {
-        interfaceFds = interfaceFds // {
-          ${id} = nextFreeFd;
-        };
-        nextFreeFd = nextFreeFd + 1;
-      }
-      else if type == "macvtap"
-      then { inherit interfaceFds nextFreeFd; }
-      else throw "Interface type not supported for crosvm: ${type}"
-    ) { interfaceFds = macvtapFds; inherit nextFreeFd; } interfaces
-  )) interfaceFds;
 
   kernelPath = {
     x86_64-linux = "${kernel.dev}/vmlinux";

--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -22,7 +22,7 @@ let
     boot-source = {
       kernel_image_path = kernelPath;
       initrd_path = initrdPath;
-      boot_args = "console=ttyS0 noapic acpi=off reboot=k panic=1 verbose i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd ${toString microvmConfig.kernelParams}";
+      boot_args = "console=ttyS0 noapic acpi=off reboot=k panic=1 verbose i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd ${builtins.unsafeDiscardStringContext (toString microvmConfig.kernelParams)}";
     };
     machine-config = {
       vcpu_count = vcpu;

--- a/lib/runners/kvmtool.nix
+++ b/lib/runners/kvmtool.nix
@@ -29,7 +29,7 @@ in {
         "--rng"
         "-k" (lib.escapeShellArg "${kernel}/${pkgs.stdenv.hostPlatform.linux-kernel.target}")
         "-i" initrdPath
-        "-p" (lib.escapeShellArg "console=ttyS0 reboot=k panic=1 ${toString microvmConfig.kernelParams}")
+        "-p" (lib.escapeShellArg "console=ttyS0 reboot=k panic=1 ${builtins.unsafeDiscardStringContext (toString microvmConfig.kernelParams)}")
       ]
       ++
       lib.optionals storeOnDisk [

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -183,10 +183,10 @@ lib.warnIf (mem == 2048) ''
     lib.optionals (system == "x86_64-linux") [
       "-device" "i8042"
 
-      "-append" "${kernelConsole} reboot=t panic=-1 ${toString microvmConfig.kernelParams}"
+      "-append" "${kernelConsole} reboot=t panic=-1 ${builtins.unsafeDiscardStringContext (toString microvmConfig.kernelParams)}"
     ] ++
     lib.optionals (system == "aarch64-linux") [
-      "-append" "${kernelConsole} reboot=t panic=-1 ${toString microvmConfig.kernelParams}"
+      "-append" "${kernelConsole} reboot=t panic=-1 ${builtins.unsafeDiscardStringContext (toString microvmConfig.kernelParams)}"
     ] ++
     lib.optionals storeOnDisk [
       "-drive" "id=store,format=raw,read-only=on,file=${storeDisk},if=none,aio=io_uring"

--- a/lib/runners/stratovirt.nix
+++ b/lib/runners/stratovirt.nix
@@ -81,7 +81,7 @@ in {
 
       "-kernel" "${kernel}/bzImage"
       "-initrd" initrdPath
-      "-append" "console=${console} edd=off reboot=t panic=-1 verbose ${toString microvmConfig.kernelParams}"
+      "-append" "console=${console} edd=off reboot=t panic=-1 verbose ${builtins.unsafeDiscardStringContext (toString microvmConfig.kernelParams)}"
 
       "-serial" "stdio"
       "-object" "rng-random,id=rng,filename=/dev/random"

--- a/nixos-modules/microvm/interfaces.nix
+++ b/nixos-modules/microvm/interfaces.nix
@@ -1,8 +1,6 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (config.networking) hostName;
-
   interfacesByType = wantedType:
     builtins.filter ({ type, ... }: type == wantedType)
       config.microvm.interfaces;
@@ -24,7 +22,7 @@ in
     lib.mkIf (tapInterfaces != []) {
       tap-up = ''
         set -eou pipefail
-      '' + lib.concatMapStrings ({ id, mac, ... }: ''
+      '' + lib.concatMapStrings ({ id, ... }: ''
         if [ -e /sys/class/net/${id} ]; then
           ${lib.getExe' pkgs.iproute2 "ip"} link delete '${id}'
         fi
@@ -35,7 +33,7 @@ in
 
       tap-down = ''
         set -ou pipefail
-      '' + lib.concatMapStrings ({ id, mac, ... }: ''
+      '' + lib.concatMapStrings ({ id, ... }: ''
         ${lib.getExe' pkgs.iproute2 "ip"} link delete '${id}'
       '') tapInterfaces;
     }

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -602,6 +602,15 @@ in
       description = "Flags to pass to gensquashfs";
       default = [ "-c" "zstd" "-j" "$NIX_BUILD_CORES" ];
     };
+
+    systemSymlink = mkOption {
+      type = types.bool;
+      default = !config.microvm.storeOnDisk;
+      description = ''
+        Whether to inclcude a symlink of `config.system.build.toplevel` to `share/microvm/system`.
+        This is required for commands like `microvm -l` to function but removes reference to the uncompressed store content when using a disk image for the nix store.
+      '';
+    };
   };
 
   config = lib.mkMerge [ {

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -1,4 +1,4 @@
-{ config, options, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 let
   self-lib = import ../../lib {
     inherit lib;
@@ -201,6 +201,7 @@ in
           :::
         '';
     };
+
     volumes = mkOption {
       description = "Disk images";
       default = [];

--- a/nixos-modules/microvm/store-disk.nix
+++ b/nixos-modules/microvm/store-disk.nix
@@ -65,13 +65,15 @@ in
           pkgs.buildPackages.time
           pkgs.buildPackages.bubblewrap
           {
-            squashfs = [ pkgs.buildPackages.squashfs-tools-ng ];
-            erofs = [ erofs-utils ];
+            squashfs = pkgs.buildPackages.squashfs-tools-ng;
+            erofs = erofs-utils;
           }.${config.microvm.storeDiskType}
         ];
         passthru = {
           inherit regInfo;
         };
+        __structuredAttrs = true;
+        unsafeDiscardReferences.out = true;
       } ''
         mkdir store
         BWRAP_ARGS="--dev-bind / / --chdir $(pwd)"


### PR DESCRIPTION
Closes #228

I kinda went and removed dead code on every file I opened while debugging.