### PR TITLE
Change TimeoutStopSec= to TimeoutSec=

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -239,7 +239,7 @@ in
           WorkingDirectory = "${stateDir}/%i";
           ExecStart = "${stateDir}/%i/current/bin/microvm-run";
           ExecStop = "${stateDir}/%i/booted/bin/microvm-shutdown";
-          TimeoutStopSec = 150;
+          TimeoutSec = 150;
           Restart = "always";
           RestartSec = "5s";
           User = user;


### PR DESCRIPTION
A previous PR #231 ("Increased microvm default timeout stop to 2m30s") changed the default TimeoutStopSec= to 150 to avoid the VMs almost finish booting, but TimeoutStopSec=[1] is the amount of time systemd waits for the service to stop, not start. Switch to TimeoutSec= to set both TimeoutStartSec= and TimeoutStopSec=.

[1] https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#TimeoutStopSec=