### PR TITLE
feat: add evaluatedConfig field

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -56,7 +56,9 @@ in
         isFlake = flake != null;
         guestConfig = if isFlake
                       then flake.nixosConfigurations.${name}.config
-                      else microvmConfig.config.config;
+                      else if microvmConfig.evaluatedConfig != null
+                        then microvmConfig.evaluatedConfig.config
+                        else microvmConfig.config.config;
         runner = guestConfig.microvm.declaredRunner;
       in
     {

--- a/nixos-modules/host/options.nix
+++ b/nixos-modules/host/options.nix
@@ -25,6 +25,15 @@
     vms = mkOption {
       type = with types; attrsOf (submodule ({ config, name, ... }: {
         options = {
+          evaluatedConfig = mkOption {
+            description = ''
+              The evaluated configuration of this MicroVM, as a NixOS
+              module, for building **with** a flake.
+            '';
+            default = null;
+            type = nullOr types.unspecified;
+          };
+
           config = mkOption {
             description = ''
               A specification of the desired configuration of this MicroVM,


### PR DESCRIPTION
This field allows using custom system configs, not necessarily nixos' eval-config