### PR TITLE
Moving pci/usb ids out of shell escaping

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -213,14 +213,14 @@ in {
         })
         else throw "Unsupported interface type ${type} for Cloud-Hypervisor"
       ) interfaces)
-      ++
-      arg "--device" (map ({ bus, path, ... }: {
+    ) 
+    + " " + # Move vfio-pci outside of
+    (lib.concatMapStringsSep " "
+      ({ bus, path, ... }: {
         pci = "path=/sys/bus/pci/devices/${path}";
         usb = throw "USB passthrough is not supported on cloud-hypervisor";
       }.${bus}) devices)
-      ++
-      extraArgs
-    );
+    + " " + lib.escapeShellArgs extraArgs;
 
   canShutdown = socket != null;
 

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -296,25 +296,25 @@ lib.warnIf (mem == 2048) ''
       "-device" "qemu-xhci"
     ]
     ++
-    builtins.concatMap ({ bus, path, qemu,... }: {
-      pci = [
-        "-device" "vfio-pci,host=${path},multifunction=on${
-          # Allow to pass additional arguments to pci device
-          lib.optionalString (qemu.deviceExtraArgs != null) ",${qemu.deviceExtraArgs}"
-        }"
-      ];
-      usb = [
-        "-device" "usb-host,${path}"
-      ];
-    }.${bus}) devices
-    ++
     lib.optionals (vsock.cid != null) [
       "-device"
       "vhost-vsock-${devType},guest-cid=${toString vsock.cid}"
     ]
     ++
     extraArgs
-  );
+  )
+  + " " + # Move vfio-pci outside of
+  (lib.concatMapStringsSep " " ({ bus, path, qemu,... }: {
+    pci = [
+      "-device" "vfio-pci,host=${path},multifunction=on${
+        # Allow to pass additional arguments to pci device
+        lib.optionalString (qemu.deviceExtraArgs != null) ",${qemu.deviceExtraArgs}"
+      }"
+    ];
+    usb = [
+      "-device" "usb-host,${path}"
+    ];
+  }.${bus}) devices);
 
   canShutdown = socket != null;
 


### PR DESCRIPTION
This is an experimental attempt to implement #350 -- a dynamic PCI device id for passthrought.

Actual change move forming part of qemu command line outside of common shell escaping, replace it with simple concatenation. This allow use something like  `vfio-pci,host=$(/path/to/detect-id.sh)`.

Weak sides:
* Currently only qemu implemented
* Very barely tested
* possible security implications (why it _was_ under escaping)
* formatting probably wrong (`nix fmt` didn't work, what you use for format)

This is (not yet) a final solution, but PoC and point for a discussion