### PR TITLE
fix(substituteAll): use replaceVars

### DIFF
--- a/nixos-modules/microvm/virtiofsd/default.nix
+++ b/nixos-modules/microvm/virtiofsd/default.nix
@@ -24,8 +24,7 @@ in
 
           "eventlistener:notify" = {
             command = pkgs.writers.writePython3 "supervisord-event-handler" { } (
-              pkgs.substituteAll {
-                src = ./supervisord-event-handler.py;
+              pkgs.replaceVars  ./supervisord-event-handler.py {
                 virtiofsdCount = builtins.length virtiofsShares;
               }
             );


### PR DESCRIPTION
substituteAll has been deprecated so will start to cause warnings on 25.05 and nixos-unstable.

https://github.com/NixOS/nixpkgs/pull/395275