### PR TITLE
fix: spectrum-os overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1746869549,
-        "narHash": "sha256-BKZ/yZO/qeLKh9YqVkKB6wJiDQJAZNN5rk5NsMImsWs=",
+        "lastModified": 1751265943,
+        "narHash": "sha256-XoHSo6GEElzRUOYAEg/jlh5c8TDsyDESFIux3nU/NMc=",
         "ref": "refs/heads/main",
-        "rev": "d927e78530892ec8ed389e8fae5f38abee00ad87",
-        "revCount": 862,
+        "rev": "37c8663fab86fdb202fece339ef7ac7177ffc201",
+        "revCount": 904,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -129,8 +129,8 @@
       }) // {
         lib = import ./lib { inherit (nixpkgs) lib; };
 
-        overlay = final: prev: {
-          cloud-hypervisor-graphics = prev.callPackage (spectrum + "/pkgs/cloud-hypervisor") {};
+        overlay = final: super: {
+          cloud-hypervisor-graphics = import "${spectrum}/pkgs/cloud-hypervisor" { inherit final super; }; 
         };
         overlays.default = self.overlay;
 


### PR DESCRIPTION
I was unable to run `cloud-hypervisor` with `graphics` enabled on `main`.

This PR:
- fixes spectrum-os `cloud-hypervisor` import
- updates spectrum-os flake to the latest version