### PR TITLE
Fix build error when using crosvm with pci passthrough

### DIFF
--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -137,7 +137,7 @@ in {
       ]
     )
     + " " + # Move vfio-pci outside of
-      (lib.concatMapStringsSep " " ({ bus, path, ... }: {
+      lib.concatStringsSep " " (lib.concatMap ({ bus, path, ... }: {
         pci = [ "--vfio" "/sys/bus/pci/devices/${path},iommu=viommu" ];
         usb = throw "USB passthrough is not supported on crosvm";
       }.${bus}) devices)


### PR DESCRIPTION
This fixes a syntax error when building a crosvm vm with pci passthrough enabled:
```
… while calling 'concatMapStringsSep'
         at /nix/store/xnr2xjs0clkhlhqfc3vqcmhnnwdk3c5p-source/lib/strings.nix:231:13:
          230|   concatMapStringsSep =
          231|     sep: f: list
             |             ^
          232|     concatStringsSep sep (map f list);
error: cannot coerce a list to a string
```