### PR TITLE
Make crosvm use virtiofsd

### DIFF
--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -97,16 +97,14 @@ in {
         ]
       ) volumes
       ++
-      builtins.concatMap ({ proto, tag, source, ... }:
-        let
-          type = {
-            "9p" = "p9";
-            "virtiofs" = "fs";
-          }.${proto};
-        in [
-          "--shared-dir" "${source}:${tag}:type=${type}"
-        ]
-      ) shares
+      builtins.concatMap ({ proto, tag, source, socket, ... }: {
+        "virtiofs" = [
+          "--vhost-user" "type=fs,socket=${socket}"
+        ];
+        "9p" = [
+          "--shared-dir" "${source}:${tag}:type=p9"
+        ];
+      }.${proto}) shares
       ++
       (builtins.concatMap ({ id, type, mac, ... }: [
         "--net"

--- a/nixos-modules/microvm/virtiofsd/default.nix
+++ b/nixos-modules/microvm/virtiofsd/default.nix
@@ -53,6 +53,9 @@ in
                   ${lib.optionalString (config.microvm.virtiofsd.inodeFileHandles != null)
                     "--inode-file-handles=${config.microvm.virtiofsd.inodeFileHandles}"
                   } \
+                  ${lib.optionalString (config.microvm.hypervisor == "crosvm")
+                    "--tag=${tag}"
+                  } \
                   ${lib.concatStringsSep " " config.microvm.virtiofsd.extraArgs}
               '';
             };


### PR DESCRIPTION
Crosvm requires the virtiofs backend to support VHOST_USER_PROTOCOL_F_CONFIG which is enabled by passing --tag to virtiofsd.

Using virtiofsd aligns crosvm with other VMMs and resolves issues with the writable /nix/store overlay.