### PR TITLE
cloud-hypervisor: allow overriding `--serial` and `--console`

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -12,7 +12,7 @@ let
 
   hasUserConsole = (extractOptValues "--console" extraArgs).values != [];
   hasUserSerial = (extractOptValues "--serial" extraArgs).values != [];
-  userSerial = if hasUserSerial then (extractOptValues "--serial" extraArgs).values else "";
+  userSerial = lib.optionalString hasUserSerial (extractOptValues "--serial" extraArgs).values;
 
   kernelPath = {
     x86_64-linux = "${kernel.dev}/vmlinux";
@@ -26,7 +26,7 @@ let
     then "console=ttyAMA0"
     else "";
 
-  kernelConsole = if (!hasUserSerial || userSerial == "tty") then kernelConsoleDefault else "";
+  kernelConsole = lib.optionalString (!hasUserSerial || userSerial == "tty") kernelConsoleDefault;
 
   kernelCmdLine = "${kernelConsole} reboot=t panic=-1 ${builtins.unsafeDiscardStringContext (toString microvmConfig.kernelParams)}";
 


### PR DESCRIPTION
cloud-hypervisor: allow overriding --serial and --console arguments

Check if --serial or --console are provided in extraArgs before adding
defaults. This allows users to specify custom values like file output
or socket connections instead of being forced to use the hardcoded
defaults. We skip the default kernel serial parameter when serial is not
set to tty.

Fixes #376

Builds on and requires ~PR #336~
