### PR TITLE
Simplify qemu shutdown script?

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -331,7 +331,7 @@ lib.warnIf (mem == 2048) ''
     then
       ''
         (
-          ${writeQmp { execute = "qmp_capabilities"; }}
+          ${writeQmp { execute = "query-commands"; }}
           ${writeQmp { execute = "system_powerdown"; }}
           # wait for exit
           cat
@@ -341,19 +341,20 @@ lib.warnIf (mem == 2048) ''
     else throw "Cannot shutdown without socket";
 
   setBalloonScript =
-    if socket != null && balloon
-    then ''
+    if balloon
+    then
+      if socket != null then
+      ''
       VALUE=$(( $SIZE * 1024 * 1024 ))
       SIZE=$( (
-        ${writeQmp { execute = "qmp_capabilities"; }}
         ${writeQmp { execute = "balloon"; arguments.value = 987; }}
       ) | sed -e s/987/$VALUE/ | \
         ${pkgs.socat}/bin/socat STDIO UNIX:${socket},shut-none | \
-        tail -n 1 | \
         ${pkgs.jq}/bin/jq -r .data.actual \
       )
       echo $(( $SIZE / 1024 / 1024 ))
-    ''
+      ''
+      else throw "Cannot balloon without socket"
     else null;
 
   requiresMacvtapAsFds = true;


### PR DESCRIPTION
https://qemu-project.gitlab.io/qemu/interop/qemu-qmp-ref.html#command-QMP-machine.system_powerdown

I'm assuming this is doing an ACPI shutdown request based on how they describe it. But that should be good enough right? For me the current keystroke sequence doesn't even work.

Also I can't help but to modify the close by balloon script as well
- Don't do anything if balloon is off
- No need to query capabilities if tail is just gonna strip it away... user can't see it anyways
- Throw if socket isn't defined as well