### PR TITLE
fix: Remove incorrect stopping signal in virtiofsd event handler

### DIFF
--- a/nixos-modules/microvm/virtiofsd/supervisord-event-handler.py
+++ b/nixos-modules/microvm/virtiofsd/supervisord-event-handler.py
@@ -37,9 +37,6 @@ def main():
         if count >= expected_count:
             subprocess.run(["systemd-notify", "--ready"])
 
-        if count <= 0:
-            subprocess.run(["systemd-notify", "--stopping"])
-
         write_stdout('RESULT 2\nOK')
 
 


### PR DESCRIPTION
- Remove incorrect "stopping" notification when processes are starting
- The handler shouldn't determine stopping state as it can't reliably detect it

fixes #382
