### PR TITLE
Allow passing extra arguments to the VMM at runtime

### DIFF
--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -43,8 +43,11 @@ let
       ${preStart}
       ${createVolumesScript vmHostPackages microvmConfig.volumes}
       ${lib.optionalString (hypervisorConfig.requiresMacvtapAsFds or false) openMacvtapFds}
+      runtime_args=${lib.optionalString (microvmConfig.extraArgsScript != null) ''
+        $(${microvmConfig.extraArgsScript})
+      ''}
 
-      exec ${execArg} ${command}
+      exec ${execArg} ${command} ''${runtime_args:-}
     '';
   } // lib.optionalAttrs canShutdown {
     microvm-shutdown = shutdownCommand;

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -63,6 +63,16 @@ in
       type = types.lines;
     };
 
+    extraArgsScript = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        A script to provide additional arguments for the hypervisor at runtime.
+
+        The script must output a single line with arguments for the hypervisor.
+      '';
+    };
+
     socket = mkOption {
       description = "Hypervisor control socket path";
       default = "${hostName}.sock";


### PR DESCRIPTION
This adds an option to pass extra arguments to the VMM at runtime via a script. It can be used to dynamically gather system information or detect devices that need to be passed to the VM before launching.