### PR TITLE
chore: replace hostName with fqdnOrHostName

### DIFF
--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -6,7 +6,7 @@
 let
   inherit (pkgs) lib;
 
-  inherit (microvmConfig) hostName vmHostPackages;
+  inherit (microvmConfig) fqdnOrHostName vmHostPackages;
 
   inherit (import ./. { inherit lib; }) makeMacvtap withDriveLetters extractOptValues extractParamValue;
   inherit (import ./volumes.nix { pkgs = microvmConfig.vmHostPackages; }) createVolumesScript;
@@ -26,7 +26,8 @@ let
   tapMultiQueue = hypervisorConfig.tapMultiQueue or false;
   setBalloonScript = hypervisorConfig.setBalloonScript or null;
 
-  execArg = lib.optionalString microvmConfig.prettyProcnames ''-a "microvm@${hostName}"'';
+  execArg = lib.optionalString microvmConfig.prettyProcnames
+    ''-a "microvm@${fqdnOrHostName}"'';
 
   # TAP interface names for machined registration
   tapInterfaces = lib.filter (i: i.type == "tap" && i ? id) microvmConfig.interfaces;
@@ -40,14 +41,14 @@ let
     else
       builtins.readFile (
         vmHostPackages.runCommand "machine-uuid" { } ''
-          ${vmHostPackages.python3}/bin/python3 -c 'import uuid; print(uuid.uuid5(uuid.NAMESPACE_DNS, "${hostName}"), end="")' > $out
+          ${vmHostPackages.python3}/bin/python3 -c 'import uuid; print(uuid.uuid5(uuid.NAMESPACE_DNS, "${fqdnOrHostName}"), end="")' > $out
         ''
       );
 
   # Script to unregister from systemd-machined
   unregisterMachineScript = ''
     set -euo pipefail
-    MACHINE_NAME="${hostName}"
+    MACHINE_NAME="${fqdnOrHostName}"
 
     # Terminate the machine registration (ignore errors if already gone)
     ${vmHostPackages.systemd}/bin/busctl call \
@@ -65,7 +66,7 @@ let
     set -euo pipefail
 
     LEADER_PID="''${1:-$$}"
-    MACHINE_NAME="${hostName}"
+    MACHINE_NAME="${fqdnOrHostName}"
     UUID="${machineUuid}"
 
     # Convert UUID to decimal bytes for busctl array arguments
@@ -207,11 +208,11 @@ let
     };
 
   binScriptPkgs = lib.mapAttrs (
-    scriptName: lines: vmHostPackages.writeShellScript "microvm-${hostName}-${scriptName}" lines
+    scriptName: lines: vmHostPackages.writeShellScript "microvm-${fqdnOrHostName}-${scriptName}" lines
   ) binScripts;
 in
 
-vmHostPackages.buildPackages.runCommand "microvm-${microvmConfig.hypervisor}-${hostName}"
+vmHostPackages.buildPackages.runCommand "microvm-${microvmConfig.hypervisor}-${fqdnOrHostName}"
 {
   # for `nix run`
   meta.mainProgram = "microvm-run";

--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -8,7 +8,7 @@ let
   inherit (pkgs) lib;
   inherit (pkgs.stdenv.hostPlatform) system;
   inherit (microvmConfig)
-    hostName user socket preStart
+    fqdnOrHostName user socket preStart
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem
     interfaces volumes shares devices
     kernel initrdPath
@@ -76,7 +76,7 @@ let
   };
   config = lib.recursiveUpdate baseConfig microvmConfig.firecracker.extraConfig;
 
-  configFile = pkgs.writers.writeJSON "firecracker-${hostName}.json" config;
+  configFile = pkgs.writers.writeJSON "firecracker-${fqdnOrHostName}.json" config;
 
   firecrackerPkg = microvmConfig.firecracker.package;
 

--- a/lib/runners/kvmtool.nix
+++ b/lib/runners/kvmtool.nix
@@ -10,7 +10,7 @@ let
   kvmtoolPkg = microvmConfig.kvmtool.package;
 
   inherit (microvmConfig)
-    hostName preStart user
+    fqdnOrHostName preStart user
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem interfaces volumes shares devices vsock
     kernel initrdPath credentialFiles
     storeDisk storeOnDisk;
@@ -34,7 +34,7 @@ in {
     else builtins.concatStringsSep " " (
       [
         "${kvmtoolPkg}/bin/lkvm" "run"
-        "--name" (lib.escapeShellArg hostName)
+        "--name" (lib.escapeShellArg fqdnOrHostName)
         "-m" (toString mem)
         "-c" (toString vcpu)
         "--console" "serial"
@@ -103,6 +103,6 @@ in {
     else
       ARGS="-i $SIZE"
     fi
-    HOME=$PWD ${kvmtoolPkg}/bin/lkvm balloon $ARGS -n ${hostName}
+    HOME=$PWD ${kvmtoolPkg}/bin/lkvm balloon $ARGS -n ${fqdnOrHostName}
   '';
 }

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -38,7 +38,7 @@ let
     then "io_uring"
     else "threads";
 
-  inherit (microvmConfig) hostName machineId vcpu mem balloon initialBalloonMem deflateOnOOM hotplugMem hotpluggedMem user interfaces shares socket forwardPorts devices vsock graphics storeOnDisk kernel initrdPath storeDisk credentialFiles;
+  inherit (microvmConfig) fqdnOrHostName machineId vcpu mem balloon initialBalloonMem deflateOnOOM hotplugMem hotpluggedMem user interfaces shares socket forwardPorts devices vsock graphics storeOnDisk kernel initrdPath storeDisk credentialFiles;
   inherit (microvmConfig.qemu) machine extraArgs serialConsole pcieRootPorts;
 
   volumes = withDriveLetters microvmConfig;
@@ -174,7 +174,7 @@ lib.warnIf (mem == 2048) ''
   else lib.escapeShellArgs (
     [
       "${qemu}/bin/qemu-system-${arch}"
-      "-name" hostName
+      "-name" fqdnOrHostName
       "-M" machineConfig
       "-m" "${toString mem}M${lib.optionalString useHotPlugMemory ",maxmem=${toString (mem + hotplugMem)}M"}"
       "-smp" (toString vcpu)
@@ -297,7 +297,7 @@ lib.warnIf (mem == 2048) ''
     lib.warnIf (
       forwardPorts != [] &&
       ! builtins.any ({ type, ... }: type == "user") interfaces
-    ) "${hostName}: forwardPortsOptions only running with user network" (
+    ) "${fqdnOrHostName}: forwardPortsOptions only running with user network" (
       builtins.concatMap ({ type, id, mac, bridge, tap ? {}, ... }: [
         "-netdev" (
           lib.concatStringsSep "," (

--- a/lib/runners/stratovirt.nix
+++ b/lib/runners/stratovirt.nix
@@ -13,7 +13,7 @@ let
   stratovirtPkg = microvmConfig.stratovirt.package;
 
   inherit (microvmConfig)
-    hostName
+    fqdnOrHostName
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem interfaces shares socket forwardPorts devices
     kernel initrdPath credentialFiles
     storeOnDisk storeDisk;
@@ -89,7 +89,7 @@ in {
     [
       "${pkgs.expect}/bin/unbuffer"
       "${stratovirtPkg}/bin/stratovirt"
-      "-name" hostName
+      "-name" fqdnOrHostName
       "-machine" machine
       "-m" (toString mem)
       "-smp" (toString vcpu)
@@ -143,7 +143,7 @@ in {
     lib.warnIf (
       forwardPorts != [] &&
       ! builtins.any ({ type, ... }: type == "user") interfaces
-    ) "${hostName}: forwardPortsOptions only running with user network" (
+    ) "${fqdnOrHostName}: forwardPortsOptions only running with user network" (
       builtins.concatMap ({ type, id, mac, bridge, ... }: [
         "-netdev" (
           lib.concatStringsSep "," (

--- a/nixos-modules/host/options.nix
+++ b/nixos-modules/host/options.nix
@@ -53,7 +53,7 @@
                     extraConfig = ({ lib, ... }: {
                       _file = "module at ${__curPos.file}:${toString __curPos.line}";
                       config = {
-                        networking.hostName = lib.mkDefault name;
+                        networking.fqdnOrHostName = lib.mkDefault name;
                       };
                     });
                   in [

--- a/nixos-modules/microvm/asserts.nix
+++ b/nixos-modules/microvm/asserts.nix
@@ -1,6 +1,6 @@
 { config, lib, ... }:
 let
-  inherit (config.networking) hostName;
+  inherit (config.networking) fqdnOrHostName;
 
 in
 lib.mkIf config.microvm.guest.enable {
@@ -9,7 +9,7 @@ lib.mkIf config.microvm.guest.enable {
     map (volumes: {
       assertion = builtins.length volumes == 1;
       message = ''
-        MicroVM ${hostName}: volume image "${(builtins.head volumes).image}" is used ${toString (builtins.length volumes)} > 1 times.
+        MicroVM ${fqdnOrHostName}: volume image "${(builtins.head volumes).image}" is used ${toString (builtins.length volumes)} > 1 times.
       '';
     }) (
       builtins.attrValues (
@@ -21,7 +21,7 @@ lib.mkIf config.microvm.guest.enable {
     map (interfaces: {
       assertion = builtins.length interfaces == 1;
       message = ''
-        MicroVM ${hostName}: interface id "${(builtins.head interfaces).id}" is used ${toString (builtins.length interfaces)} > 1 times.
+        MicroVM ${fqdnOrHostName}: interface id "${(builtins.head interfaces).id}" is used ${toString (builtins.length interfaces)} > 1 times.
       '';
     }) (
       builtins.attrValues (
@@ -35,14 +35,14 @@ lib.mkIf config.microvm.guest.enable {
       then {
         assertion = bridge != null;
         message = ''
-          MicroVM ${hostName}: interface ${id} is of type "bridge"
+          MicroVM ${fqdnOrHostName}: interface ${id} is of type "bridge"
           but doesn't have a bridge to attach to defined.
         '';
       }
       else {
         assertion = bridge == null;
         message = ''
-          MicroVM ${hostName}: interface ${id} is not of type "bridge"
+          MicroVM ${fqdnOrHostName}: interface ${id} is not of type "bridge"
           and therefore shouldn't have a "bridge" option defined.
         '';
       }
@@ -52,7 +52,7 @@ lib.mkIf config.microvm.guest.enable {
     map ({ id, ... }: {
       assertion = builtins.stringLength id <= 15;
       message = ''
-        MicroVM ${hostName}: interface name ${id} is longer than the
+        MicroVM ${fqdnOrHostName}: interface name ${id} is longer than the
         the maximum length of 15 characters on Linux.
       '';
     }) config.microvm.interfaces
@@ -61,7 +61,7 @@ lib.mkIf config.microvm.guest.enable {
     map (shares: {
       assertion = builtins.length shares == 1;
       message = ''
-        MicroVM ${hostName}: share tag "${(builtins.head shares).tag}" is used ${toString (builtins.length shares)} > 1 times.
+        MicroVM ${fqdnOrHostName}: share tag "${(builtins.head shares).tag}" is used ${toString (builtins.length shares)} > 1 times.
       '';
     }) (
       builtins.attrValues (
@@ -73,7 +73,7 @@ lib.mkIf config.microvm.guest.enable {
     map (shares: {
       assertion = builtins.length shares == 1;
       message = ''
-        MicroVM ${hostName}: share socket "${(builtins.head shares).socket}" is used ${toString (builtins.length shares)} > 1 times.
+        MicroVM ${fqdnOrHostName}: share socket "${(builtins.head shares).socket}" is used ${toString (builtins.length shares)} > 1 times.
       '';
     }) (
       builtins.attrValues (
@@ -88,7 +88,7 @@ lib.mkIf config.microvm.guest.enable {
     map ({ tag, socket, ... }: {
       assertion = socket != null;
       message = ''
-        MicroVM ${hostName}: virtiofs share with tag "${tag}" is missing a `socket` path.
+        MicroVM ${fqdnOrHostName}: virtiofs share with tag "${tag}" is missing a `socket` path.
       '';
     }) (
       builtins.filter ({ proto, ... }: proto == "virtiofs")
@@ -103,7 +103,7 @@ lib.mkIf config.microvm.guest.enable {
           builtins.any ({ type, ... }: type == "user") config.microvm.interfaces
         );
       message = ''
-        MicroVM ${hostName}: `config.microvm.forwardPorts` works only with qemu and one network interface with `type = "user"`
+        MicroVM ${fqdnOrHostName}: `config.microvm.forwardPorts` works only with qemu and one network interface with `type = "user"`
       '';
     } ]
     ++
@@ -111,7 +111,7 @@ lib.mkIf config.microvm.guest.enable {
     lib.optionals (config.microvm.hypervisor == "cloud-hypervisor") [ {
       assertion = ! (lib.any (str: lib.hasInfix "oem_strings" str) config.microvm.cloud-hypervisor.platformOEMStrings);
       message = ''
-        MicroVM ${hostName}: `config.microvm.cloud-hypervisor.platformOEMStrings` items must not contain `oem_strings`
+        MicroVM ${fqdnOrHostName}: `config.microvm.cloud-hypervisor.platformOEMStrings` items must not contain `oem_strings`
       '';
     } ];
 
@@ -119,7 +119,7 @@ lib.mkIf config.microvm.guest.enable {
   warnings =
     # 32 MB is just an optimistic guess, not based on experience
     lib.optional (config.microvm.mem < 32) ''
-      MicroVM ${hostName}: ${toString config.microvm.mem} MB of RAM is uncomfortably narrow.
+      MicroVM ${fqdnOrHostName}: ${toString config.microvm.mem} MB of RAM is uncomfortably narrow.
     ''
     ++ lib.optional config.nix.optimise.automatic ''
       Optimising the nix store is not recommended as it either uses lots of file handles with virtiofsd or as it doesn't do what you expect with a block device.

--- a/nixos-modules/microvm/default.nix
+++ b/nixos-modules/microvm/default.nix
@@ -30,7 +30,7 @@ in
       microvm-lib.buildRunner {
         inherit pkgs;
         microvmConfig = config.microvm // {
-          inherit (config.networking) hostName;
+          inherit (config.networking) fqdnOrHostName;
           inherit hypervisor;
         };
         inherit (config.system.build) toplevel;

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -5,7 +5,7 @@ let
   };
 
   cfg = config.microvm;
-  hostName = config.networking.hostName or "$HOSTNAME";
+  fqdnOrHostName = config.networking.fqdnOrHostName or "$HOSTNAME";
   kernelAtLeast = lib.versionAtLeast config.boot.kernelPackages.kernel.version;
 in
 {
@@ -76,8 +76,8 @@ in
 
     socket = mkOption {
       description = "Hypervisor control socket path";
-      default = "${hostName}.sock";
-      defaultText = literalExpression ''"''${hostName}.sock"'';
+      default = "${fqdnOrHostName}.sock";
+      defaultText = literalExpression ''"''${fqdnOrHostName}.sock"'';
       type = with types; nullOr str;
     };
 
@@ -383,7 +383,7 @@ in
             type = nullOr str;
             default =
               if config.proto == "virtiofs"
-              then "${hostName}-virtiofs-${config.tag}.sock"
+              then "${fqdnOrHostName}-virtiofs-${config.tag}.sock"
               else null;
             description = "Socket for communication with virtiofs daemon";
           };
@@ -514,7 +514,7 @@ in
       type = with types; nullOr str;
       default =
         let
-          hash = builtins.hashString "sha256" "microvm.nix:${hostName}";
+          hash = builtins.hashString "sha256" "microvm.nix:${fqdnOrHostName}";
           hs = offset: len:
             builtins.substring offset len hash;
         in builtins.concatStringsSep "-" [
@@ -611,7 +611,7 @@ in
 
       socket = mkOption {
         type = types.str;
-        default = "${hostName}-gpu.sock";
+        default = "${fqdnOrHostName}-gpu.sock";
         description = ''
           Path of vhost-user socket
         '';

--- a/nixos-modules/microvm/ssh-deploy.nix
+++ b/nixos-modules/microvm/ssh-deploy.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  hostName = config.networking.hostName or "$HOSTNAME";
+  fqdnOrHostName = config.networking.fqdnOrHostName or "$HOSTNAME";
   inherit (config.system.build) toplevel;
   inherit (config.microvm) declaredRunner;
   inherit (config) nix;
@@ -42,8 +42,8 @@ in
         `microvm.nixosModules.host`:
 
         ```
-        nix run .#nixosConfigurations.${hostName}.config.microvm.deploy.installOnHost root@example.com
-        ssh root@example.com systemctl restart microvm@${hostName}
+        nix run .#nixosConfigurations.${fqdnOrHostName}.config.microvm.deploy.installOnHost root@example.com
+        ssh root@example.com systemctl restart microvm@${fqdnOrHostName}
         ```
 
         - Evaluate this MicroVM to a derivation
@@ -52,7 +52,7 @@ in
         - Install/update the MicroVM on the target host
 
         Can be followed by either:
-        - `systemctl restart microvm@${hostName}.service` on the
+        - `systemctl restart microvm@${fqdnOrHostName}.service` on the
           target host, or
         - `config.microvm.deploy.sshSwitch`
       '';
@@ -69,8 +69,8 @@ in
         `microvm.deploy.installOnHost` like this:
 
         ```
-        nix run .#nixosConfigurations.${hostName}.config.microvm.deploy.installOnHost root@example.com
-        nix run .#nixosConfigurations.${hostName}.config.microvm.deploy.sshSwitch root@my-microvm.example.com switch
+        nix run .#nixosConfigurations.${fqdnOrHostName}.config.microvm.deploy.installOnHost root@example.com
+        nix run .#nixosConfigurations.${fqdnOrHostName}.config.microvm.deploy.sshSwitch root@my-microvm.example.com switch
         ```
       '';
       type = with lib.types; nullOr package;
@@ -84,7 +84,7 @@ in
         MicroVM.
 
         ```
-        nix run .#nixosConfigurations.${hostName}.config.microvm.deploy.rebuild root@example.com root@my-microvm.example.com switch
+        nix run .#nixosConfigurations.${fqdnOrHostName}.config.microvm.deploy.rebuild root@example.com root@my-microvm.example.com switch
         ```
       '';
       type = with lib.types; nullOr package;
@@ -126,15 +126,15 @@ in
       ssh "$HOST" -- $SSH_CMD -e <<__SSH__
       set -eou pipefail
 
-      echo "Initializing MicroVM ${hostName} if necessary"
+      echo "Initializing MicroVM ${fqdnOrHostName} if necessary"
       mkdir -p /nix/var/nix/gcroots/microvm
-      mkdir -p /var/lib/microvms/${hostName}
-      cd /var/lib/microvms/${hostName}
+      mkdir -p /var/lib/microvms/${fqdnOrHostName}
+      cd /var/lib/microvms/${fqdnOrHostName}
       chown microvm:kvm .
       chmod 0755 .
-      ln -sfT \$PWD/current /nix/var/nix/gcroots/microvm/${hostName}
-      ln -sfT \$PWD/booted /nix/var/nix/gcroots/microvm/booted-${hostName}
-      ln -sfT \$PWD/old /nix/var/nix/gcroots/microvm/old-${hostName}
+      ln -sfT \$PWD/current /nix/var/nix/gcroots/microvm/${fqdnOrHostName}
+      ln -sfT \$PWD/booted /nix/var/nix/gcroots/microvm/booted-${fqdnOrHostName}
+      ln -sfT \$PWD/old /nix/var/nix/gcroots/microvm/old-${fqdnOrHostName}
 
       echo "Building toplevel ${paths.toplevelOut}"
       nix build -L --accept-flake-config --no-link \
@@ -143,12 +143,12 @@ in
           closureInfoDrv
           toplevelDrv
         ]}
-      echo "Building MicroVM runner for ${hostName}"
+      echo "Building MicroVM runner for ${fqdnOrHostName}"
       nix build -L --accept-flake-config -o new \
         "${paths.runnerDrv}^out"
 
       if [[ $(realpath ./current) != $(realpath ./new) ]]; then
-        echo "Installing MicroVM ${hostName}"
+        echo "Installing MicroVM ${fqdnOrHostName}"
         rm -f old
         if [ -e current ]; then
           mv current old
@@ -164,7 +164,7 @@ in
           echo "Success."
         fi
       else
-        echo "MicroVM ${hostName} is already installed"
+        echo "MicroVM ${fqdnOrHostName} is already installed"
       fi
       __SSH__
     '';
@@ -195,9 +195,9 @@ in
         ssh "$TARGET" $SSH_CMD -e <<__SSH__
         set -eou pipefail
 
-        hostname=\$(cat /etc/hostname)
-        if [[ "\$hostname" != "${hostName}" ]]; then
-          echo "Attempting to deploy NixOS ${hostName} on host \$hostname"
+        fqdnOrHostName=\$(cat /etc/fqdn)
+        if [[ "\$fqdnOrHostName" != "${fqdnOrHostName}" ]]; then
+          echo "Attempting to deploy NixOS ${fqdnOrHostName} on host \$fqdnOrHostName"
           exit 1
         fi
 
@@ -233,7 +233,7 @@ in
       ${lib.getExe installOnHost} "$HOST" $OPTS
       ${if canSwitchViaSsh
         then ''${lib.getExe sshSwitch} "$TARGET" $OPTS''
-        else ''ssh "$HOST" -- systemctl restart "microvm@${hostName}.service"''
+        else ''ssh "$HOST" -- systemctl restart "microvm@${fqdnOrHostName}.service"''
        }
     '';
   };

--- a/nixos-modules/microvm/virtiofsd/default.nix
+++ b/nixos-modules/microvm/virtiofsd/default.nix
@@ -66,7 +66,7 @@ in
         );
 
         supervisordConfigFile =
-          pkgs.writeText "${config.networking.hostName}-virtiofsd-supervisord.conf" (
+          pkgs.writeText "${config.networking.fqdnOrHostName}-virtiofsd-supervisord.conf" (
             lib.generators.toINI {} supervisordConfig
           );
 

--- a/pkgs/build-microvm.nix
+++ b/pkgs/build-microvm.nix
@@ -54,7 +54,7 @@ writeShellScriptBin "build-microvm" ''
   in self.lib.buildRunner {
     inherit pkgs;
     microvmConfig = {
-      inherit (extended.config.networking) hostName;
+      inherit (extended.config.networking) fqdnOrHostName;
     } // extended.config.microvm;
     inherit (extended.config.system.build) toplevel;
   }"


### PR DESCRIPTION
Using fully qualified domain names as unique identifier for containers improves identification of containers on large (potentially multi tenant) hypervisors.

In the current version using a container name containing a dot doesn't work. I forked microvm.nix and adjusted it so that fqdn's are used by default.

Should we try to upstream this? If yes how?

I drafted this change because merging this would result in breaking changes if `networking.domain` is being set for a machine.