### PR TITLE
Allow using microvm.interfaces.*.type = "vmnet-shared" for addressable darwin networking

### DIFF
--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -296,7 +296,7 @@ in
       type = with types; listOf (submodule {
         options = {
           type = mkOption {
-            type = enum [ "user" "tap" "macvtap" "bridge" ];
+            type = enum [ "user" "tap" "macvtap" "bridge" "vmnet-shared" ];
             description = ''
               Interface type
             '';


### PR DESCRIPTION
As `tap`/`macvtap` is a bit tricky on darwin and `user` networking doesn't create a routable IP + port forwarding doesn't seem to work with `hvf` virt accel.