### PR TITLE
Directory permissions for ${stateDir} are set wrongly on the initial creation of it

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -27,7 +27,7 @@ in
     system.activationScripts.microvm-host = ''
       mkdir -p ${stateDir}
       chown ${user}:${group} ${stateDir}
-      chmod 775 ${stateDir}
+      chmod u+rwx,g+w ${stateDir}
     '';
 
     environment.systemPackages = [


### PR DESCRIPTION
Problem: On the first usage of microvm in host mode, on my machine the state directory is created with `rw-r rwx r-x` permissions. This results in the systemd units failing with `Changing to the requested working directory failed: Permission denied` since the user `microvm` is not allowed to chdir to the `${stateDir}`

One possible solution: Change the permission of the `${stateDir}` to `775` during activation.