### PR TITLE
fix: replace deprecated pkgs.system with pkgs.stdenv.hostPlatform.system

### DIFF
--- a/nixos-modules/host/options.nix
+++ b/nixos-modules/host/options.nix
@@ -53,7 +53,11 @@
                   ] ++ (map (x: x.value) defs);
                 prefix = [ "microvm" "vms" name "config" ];
                 inherit (config) specialArgs pkgs;
-                system = if config.pkgs != null then config.pkgs.system else pkgs.system;
+                system = 
+                  if config.pkgs != null then 
+                    config.pkgs.stdenv.hostPlatform.system
+                  else 
+                    pkgs.stdenv.hostPlatform.system;
               });
             });
           };


### PR DESCRIPTION
Minor fix for deprecation warning of pkgs.system; see https://github.com/NixOS/nixpkgs/commit/90cb7876446bf1684ffe40ab7832de0ec1b92991