### PR TITLE
aliases: fix the warnings from nixpkgs change

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,7 +112,7 @@
               name = builtins.replaceStrings [ "${system}-" ] [ "" ] systemName;
               inherit (nixos.config.microvm) hypervisor;
             in
-              if nixos.pkgs.system == nixpkgs.lib.replaceString "-darwin" "-linux" system
+              if nixos.pkgs.stdenv.hostPlatform.system == nixpkgs.lib.replaceString "-darwin" "-linux" system
               then result // {
                 "${name}" = nixos.config.microvm.runner.${hypervisor};
               }

--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -24,12 +24,12 @@ let
   kernelPath = {
     x86_64-linux = "${kernel.dev}/vmlinux";
     aarch64-linux = "${kernel.out}/${pkgs.stdenv.hostPlatform.linux-kernel.target}";
-  }.${pkgs.stdenv.system};
+  }.${pkgs.stdenv.hostPlatform.system};
 
   kernelConsoleDefault =
-    if pkgs.stdenv.system == "x86_64-linux"
+    if pkgs.stdenv.hostPlatform.system == "x86_64-linux"
     then "earlyprintk=ttyS0 console=ttyS0"
-    else if pkgs.stdenv.system == "aarch64-linux"
+    else if pkgs.stdenv.hostPlatform.system == "aarch64-linux"
     then "console=ttyAMA0"
     else "";
 

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -6,7 +6,7 @@
 
 let
   inherit (pkgs) lib;
-  inherit (pkgs.stdenv) system;
+  inherit (pkgs.stdenv.hostPlatform) system;
   inherit (microvmConfig)
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem user volumes shares
     socket devices vsock graphics credentialFiles

--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -4,7 +4,8 @@
 }:
 
 let
-  inherit (pkgs) lib system;
+  inherit (pkgs) lib;
+  inherit (pkgs.stdenv.hostPlatform) system;
   inherit (microvmConfig)
     hostName user socket preStart
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -7,7 +7,7 @@
 
 let
   inherit (pkgs) lib;
-  inherit (pkgs.stdenv) system;
+  inherit (pkgs.stdenv.hostPlatform) system;
   inherit (microvmConfig) vmHostPackages;
 
   enableLibusb = pkg: pkg.overrideAttrs (oa: {

--- a/lib/runners/stratovirt.nix
+++ b/lib/runners/stratovirt.nix
@@ -6,7 +6,8 @@
 }:
 
 let
-  inherit (pkgs) lib system;
+  inherit (pkgs) lib;
+  inherit (pkgs.stdenv.hostPlatform) system;
 
   inherit (microvmConfig)
     hostName

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -730,12 +730,12 @@ in
 
   config = lib.mkMerge [ {
     microvm.qemu.machine =
-      lib.mkIf (pkgs.stdenv.system == "x86_64-linux") (
+      lib.mkIf (pkgs.stdenv.hostPlatform.system == "x86_64-linux") (
         lib.mkDefault "microvm"
       );
   } {
     microvm.qemu.machine =
-      lib.mkIf (pkgs.stdenv.system == "aarch64-linux") (
+      lib.mkIf (pkgs.stdenv.hostPlatform.system == "aarch64-linux") (
         lib.mkDefault "virt"
       );
   } ];


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/90cb7876446bf1684ffe40ab7832de0ec1b92991 changes the aliases and now warns of improper use of the properties. Adjust to use the correct references and remove the eval warnings.