### PR TITLE
firecracker: Set --enable-pci option by default when available

### DIFF
--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -94,7 +94,7 @@ in {
         then socket
         else throw "Firecracker must be configured with an API socket (option microvm.socket)!"
       )
-    ];
+    ] ++ lib.optional enablePci "--enable-pci";
 
   preStart = ''
     ${preStart}

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -590,6 +590,12 @@ in
       description = "Custom CPU template passed to firecracker.";
     };
 
+    firecracker.enablePci = mkOption {
+      type = types.bool;
+      default = lib.versionOlder "1.13.0" pkgs.firecracker.version;
+      description = "Use PCI Virtio transport, improves performance.";
+    };
+
     prettyProcnames = mkOption {
       type = types.bool;
       default = true;


### PR DESCRIPTION
This enables the PCI virtio transport which is dramatically faster than the MMIO one.

Support for this flag is currently only availble in Nixpkgs unstable.

However I'm not aware of any reason for _not_ setting this when it's available, so when it is, set it by default.