### PR TITLE
firecracker: Set --enable-pci option by default when available

### DIFF
--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -86,7 +86,7 @@ in {
     then throw "hotpluggedMem not implemented for Firecracker"
     else if credentialFiles != {}
     then throw "credentialFiles are not implemented for Firecracker"
-    else lib.escapeShellArgs [
+    else lib.escapeShellArgs ([
       "${pkgs.firecracker}/bin/firecracker"
       "--config-file" configFile
       "--api-sock" (
@@ -94,7 +94,7 @@ in {
         then socket
         else throw "Firecracker must be configured with an API socket (option microvm.socket)!"
       )
-    ];
+    ] ++ lib.optional (lib.versionAtLeast pkgs.firecracker.version "1.13.0") "--enable-pci");
 
   preStart = ''
     ${preStart}


### PR DESCRIPTION
This enables the PCI virtio transport which is supposed to be faster than the MMIO one.

Support for this flag is currently only availble in Nixpkgs unstable.

I haven't been able to measure these perf improvements.

However this is still what the Firecracker docs say to do, so I guess let's make it the default?