### PR TITLE
firecracker: Increase serial baudrate

### DIFF
--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -24,7 +24,7 @@ let
     boot-source = {
       kernel_image_path = kernelPath;
       initrd_path = initrdPath;
-      boot_args = "console=ttyS0 noapic acpi=off reboot=k panic=1 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd ${toString microvmConfig.kernelParams}";
+      boot_args = "console=ttyS0,115200 noapic acpi=off reboot=k panic=1 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd ${toString microvmConfig.kernelParams}";
     };
     machine-config = {
       vcpu_count = vcpu;


### PR DESCRIPTION
By default the kernel uses a slow baudrate which, at least on my host, slows down boot by about 10 seconds.