### PR TITLE
feat: implement `microvm.vms.*.extraModules`

### DIFF
--- a/nixos-modules/host/options.nix
+++ b/nixos-modules/host/options.nix
@@ -52,7 +52,7 @@
                     ../microvm
                   ] ++ (map (x: x.value) defs);
                 prefix = [ "microvm" "vms" name "config" ];
-                inherit (config) specialArgs pkgs;
+                inherit (config) extraModules specialArgs pkgs;
                 system =
                   if config.pkgs != null then
                     config.pkgs.stdenv.hostPlatform.system
@@ -99,6 +99,23 @@
               A set of special arguments to be passed to NixOS modules.
               This will be merged into the `specialArgs` used to evaluate
               the NixOS configurations.
+            '';
+          };
+
+          extraModules = mkOption {
+            type = types.listOf types.deferredModule;
+            default = [];
+            description = ''
+              This option is only respected when `config` is specified.
+
+              A list of additional NixOS modules to be merged into
+              the MicroVM's system configuration.
+            '';
+            defaultText = literalExpression ''
+              [
+                flakeInputs.some-project.nixosModules.example
+                flakeInputs.another-project.nixosModules.default
+              ]
             '';
           };
 


### PR DESCRIPTION
Adds an option at `microvm.vms.*.extraModules` which allows users to pass in a list of NixOS Modules that will be merged into `microvm.vms.*.config`, enabling fully-declarative MicroVM setups to use existing NixOS Modules from other projects.

This is achieved by passing the `extraModules` option through as [an argument to `lib/eval-config.nix`](https://github.com/NixOS/nixpkgs/blob/256e2076ea1aac921f970927c58e1737072cf463/nixos/lib/eval-config.nix#L33C1-L33C22).

Fixes #197.