### PR TITLE
fix: don't copy nixpkgs to the store needlessly

### DIFF
--- a/nixos-modules/host/options.nix
+++ b/nixos-modules/host/options.nix
@@ -38,7 +38,7 @@
             default = null;
             type = nullOr (lib.mkOptionType {
               name = "Toplevel NixOS config";
-              merge = loc: defs: (import "${config.nixpkgs}/nixos/lib/eval-config.nix" {
+              merge = loc: defs: (import "${toString config.nixpkgs}/nixos/lib/eval-config.nix" {
                 modules =
                   let
                     extraConfig = ({ lib, ... }: {


### PR DESCRIPTION
if the value of nixpkgs is a path, it will be copied to the store by nix's implicit interpolation. Coercing it to a string beforehand should resolve this.

resolves #435