### PR TITLE
fix: append dont clear

### DIFF
--- a/nixos-modules/microvm/mounts.nix
+++ b/nixos-modules/microvm/mounts.nix
@@ -87,7 +87,7 @@ lib.mkIf config.microvm.guest.enable {
           upperdir = "${writableStoreOverlay}/store";
           workdir = "${writableStoreOverlay}/work";
         };
-        options = lib.optional isRwStoreVirtiofsShare "userxattr";
+        options = lib.mkIf isRwStoreVirtiofsShare [ "userxattr" ];
       };
     }
   ) {


### PR DESCRIPTION
lib.optional returns the empty set [] when a check is false. In this case it causes the options to be set to an empty list which the module does not allow. So append the new options if true.

issue introduced from (https://github.com/microvm-nix/microvm.nix/pull/419)