### PR TITLE
Remove external dependency on `flake-utils`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1759381078,
@@ -36,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "spectrum": "spectrum"
       }
@@ -55,21 +36,6 @@
       "original": {
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -8,278 +8,282 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     spectrum = {
       url = "git+https://spectrum-os.org/git/spectrum";
       flake = false;
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, spectrum }:
+  outputs = { self, nixpkgs, spectrum }:
     let
+      forAllSystems = function: nixpkgs.lib.genAttrs systems (system: function system);
       systems = [
         "x86_64-linux"
         "aarch64-linux"
         "x86_64-darwin"
         "aarch64-darwin"
       ];
-    in
-      flake-utils.lib.eachSystem systems (system: {
+    in {
+      apps = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          nixosToApp = configFile: {
+            type = "app";
+            program = "${(import configFile {
+              inherit self nixpkgs system;
+            }).config.microvm.declaredRunner}/bin/microvm-run";
+          };
+        in {
+          vm = nixosToApp ./examples/microvms-host.nix;
+          qemu-vnc = nixosToApp ./examples/qemu-vnc.nix;
+          graphics = {
+            type = "app";
+            program = toString (pkgs.writeShellScript "run-graphics" ''
+              set -e
 
-        apps =
-          let
-            pkgs = nixpkgs.legacyPackages.${system};
-            nixosToApp = configFile: {
-              type = "app";
-              program = "${(import configFile {
-                inherit self nixpkgs system;
-              }).config.microvm.declaredRunner}/bin/microvm-run";
-            };
-          in {
-            vm = nixosToApp ./examples/microvms-host.nix;
-            qemu-vnc = nixosToApp ./examples/qemu-vnc.nix;
-            graphics = {
-              type = "app";
-              program = toString (pkgs.writeShellScript "run-graphics" ''
-                set -e
+              if [ -z "$*" ]; then
+                echo "Usage: $0 [--tap tap0] <pkgs...>"
+                exit 1
+              fi
 
-                if [ -z "$*" ]; then
-                  echo "Usage: $0 [--tap tap0] <pkgs...>"
-                  exit 1
-                fi
+              if [ "$1" = "--tap" ]; then
+                TAP_INTERFACE="\"$2\""
+                shift 2
+              else
+                TAP_INTERFACE=null
+              fi
 
-                if [ "$1" = "--tap" ]; then
-                  TAP_INTERFACE="\"$2\""
-                  shift 2
-                else
-                  TAP_INTERFACE=null
-                fi
+              ${pkgs.nix}/bin/nix run \
+                -f ${./examples/graphics.nix} \
+                config.microvm.declaredRunner \
+                --arg self 'builtins.getFlake "${self}"' \
+                --arg system '"${system}"' \
+                --arg nixpkgs 'builtins.getFlake "${nixpkgs}"' \
+                --arg packages "\"$*\"" \
+                --arg tapInterface "$TAP_INTERFACE"
+            '');
+          };
+          # Run this on your host to accept Wayland connections
+          # on AF_VSOCK.
+          waypipe-client = {
+            type = "app";
+            program = toString (pkgs.writeShellScript "waypipe-client" ''
+              exec ${pkgs.waypipe}/bin/waypipe --vsock -s 6000 client
+            '');
+          };
+        }
+      );
 
-                ${pkgs.nix}/bin/nix run \
-                  -f ${./examples/graphics.nix} \
-                  config.microvm.declaredRunner \
-                  --arg self 'builtins.getFlake "${self}"' \
-                  --arg system '"${system}"' \
-                  --arg nixpkgs 'builtins.getFlake "${nixpkgs}"' \
-                  --arg packages "\"$*\"" \
-                  --arg tapInterface "$TAP_INTERFACE"
-              '');
-            };
-            # Run this on your host to accept Wayland connections
-            # on AF_VSOCK.
-            waypipe-client = {
-              type = "app";
-              program = toString (pkgs.writeShellScript "waypipe-client" ''
-                exec ${pkgs.waypipe}/bin/waypipe --vsock -s 6000 client
-              '');
-            };
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ self.overlay ];
           };
 
-        packages =
-          let
-            pkgs = import nixpkgs {
-              inherit system;
-              overlays = [ self.overlay ];
-            };
+          inherit (pkgs) lib;
+        in {
+          build-microvm = pkgs.callPackage ./pkgs/build-microvm.nix { inherit self; };
+          doc = pkgs.callPackage ./pkgs/doc.nix { };
+          microvm = import ./pkgs/microvm-command.nix {
+            pkgs = import nixpkgs { inherit system; };
+          };
+          # all compilation-heavy packages that shall be prebuilt for a binary cache
+          prebuilt = pkgs.buildEnv {
+            name = "prebuilt";
+            paths = with self.packages.${system}; with pkgs; [
+              qemu-example
+              cloud-hypervisor-example
+              firecracker-example
+              crosvm-example
+              kvmtool-example
+              stratovirt-example
+              # alioth-example
+              virtiofsd
+            ];
+            pathsToLink = [ "/" ];
+            extraOutputsToInstall = [ "dev" ];
+            ignoreCollisions = true;
+          };
+        } //
+        # wrap self.nixosConfigurations in executable packages
+        lib.listToAttrs (
+          lib.concatMap (configName:
+            let
+              config = self.nixosConfigurations.${configName};
+              packageName = lib.replaceString "${system}-" "" configName;
+              # Check if this config's guest system matches our current build system
+              # (accounting for darwin hosts building linux guests)
+              guestSystem = config.pkgs.stdenv.hostPlatform.system;
+              buildSystem = lib.replaceString "-darwin" "-linux" system;
+            in
+            lib.optional (guestSystem == buildSystem)
+            {
+              name = packageName;
+              value = config.config.microvm.runner.${config.config.microvm.hypervisor};
+            }
+          ) (builtins.attrNames self.nixosConfigurations)
+        )
+      );
 
-            inherit (pkgs) lib;
-          in {
-            build-microvm = pkgs.callPackage ./pkgs/build-microvm.nix { inherit self; };
-            doc = pkgs.callPackage ./pkgs/doc.nix { };
-            microvm = import ./pkgs/microvm-command.nix {
-              pkgs = import nixpkgs { inherit system; };
-            };
-            # all compilation-heavy packages that shall be prebuilt for a binary cache
-            prebuilt = pkgs.buildEnv {
-              name = "prebuilt";
-              paths = with self.packages.${system}; with pkgs; [
-                qemu-example
-                cloud-hypervisor-example
-                firecracker-example
-                crosvm-example
-                kvmtool-example
-                stratovirt-example
-                # alioth-example
-                virtiofsd
-              ];
-              pathsToLink = [ "/" ];
-              extraOutputsToInstall = [ "dev" ];
-              ignoreCollisions = true;
-            };
-          } //
-          # wrap self.nixosConfigurations in executable packages
-          lib.listToAttrs (
-            lib.concatMap (configName:
-              let
-                config = self.nixosConfigurations.${configName};
-                packageName = lib.replaceString "${system}-" "" configName;
-                # Check if this config's guest system matches our current build system
-                # (accounting for darwin hosts building linux guests)
-                guestSystem = config.pkgs.stdenv.hostPlatform.system;
-                buildSystem = lib.replaceString "-darwin" "-linux" system;
-              in
-              lib.optional (guestSystem == buildSystem)
-              {
-                name = packageName;
-                value = config.config.microvm.runner.${config.config.microvm.hypervisor};
-              }
-            ) (builtins.attrNames self.nixosConfigurations)
-          );
+      # Takes too much memory in `nix flake show`
+      # checks = forAllSystems (system: 
+      #   import ./checks { inherit self nixpkgs system; };
+      # );
 
-        # Takes too much memory in `nix flake show`
-        # checks = import ./checks { inherit self nixpkgs system; };
-
-        # hydraJobs are checks
-        hydraJobs = builtins.mapAttrs (_: check:
+      # hydraJobs are checks
+      hydraJobs = forAllSystems (system: 
+        builtins.mapAttrs (_: check:
           (nixpkgs.lib.recursiveUpdate check {
             meta.timeout = 12 * 60 * 60;
           })
-        ) (import ./checks { inherit self nixpkgs system; });
-      }) // {
-        lib = import ./lib { inherit (nixpkgs) lib; };
+        ) (import ./checks { inherit self nixpkgs system; })
+      );
 
-        overlay = final: super: {
-          cloud-hypervisor-graphics = import "${spectrum}/pkgs/cloud-hypervisor" { inherit final super; };
-        };
-        overlays.default = self.overlay;
+      lib = import ./lib { inherit (nixpkgs) lib; };
 
-        nixosModules = {
-          microvm = ./nixos-modules/microvm;
-          host = ./nixos-modules/host;
-          # Just the generic microvm options
-          microvm-options = ./nixos-modules/microvm/options.nix;
-        };
+      overlay = final: super: {
+        cloud-hypervisor-graphics = import "${spectrum}/pkgs/cloud-hypervisor" { inherit final super; };
+      };
+      overlays.default = self.overlay;
 
-        defaultTemplate = self.templates.microvm;
-        templates.microvm = {
-          path = ./flake-template;
-          description = "Flake with MicroVMs";
-        };
+      nixosModules = {
+        microvm = ./nixos-modules/microvm;
+        host = ./nixos-modules/host;
+        # Just the generic microvm options
+        microvm-options = ./nixos-modules/microvm/options.nix;
+      };
 
-        nixosConfigurations =
-          let
-            inherit (nixpkgs) lib;
+      defaultTemplate = self.templates.microvm;
+      templates.microvm = {
+        path = ./flake-template;
+        description = "Flake with MicroVMs";
+      };
 
-            hypervisorsWith9p = [
-              "qemu"
-              # currently broken:
-              # "crosvm"
-            ];
-            hypervisorsWithUserNet = [ "qemu" "kvmtool" "vfkit" ];
-            hypervisorsDarwinOnly = [ "vfkit" ];
-            # Hypervisors that work on darwin (qemu via HVF, vfkit natively)
-            hypervisorsOnDarwin = [ "qemu" "vfkit" ];
-            hypervisorsWithTap = builtins.filter
-              # vfkit supports networking, but does not support tap
-              (hv: hv != "vfkit")
-              self.lib.hypervisorsWithNetwork;
+      nixosConfigurations =
+        let
+          inherit (nixpkgs) lib;
 
-            isDarwinOnly = hypervisor: builtins.elem hypervisor hypervisorsDarwinOnly;
-            isDarwinSystem = system: lib.hasSuffix "-darwin" system;
-            hypervisorSupportsSystem = hypervisor: system:
-              if isDarwinSystem system
-              then builtins.elem hypervisor hypervisorsOnDarwin
-              else !(isDarwinOnly hypervisor);
+          hypervisorsWith9p = [
+            "qemu"
+            # currently broken:
+            # "crosvm"
+          ];
+          hypervisorsWithUserNet = [ "qemu" "kvmtool" "vfkit" ];
+          hypervisorsDarwinOnly = [ "vfkit" ];
+          # Hypervisors that work on darwin (qemu via HVF, vfkit natively)
+          hypervisorsOnDarwin = [ "qemu" "vfkit" ];
+          hypervisorsWithTap = builtins.filter
+            # vfkit supports networking, but does not support tap
+            (hv: hv != "vfkit")
+            self.lib.hypervisorsWithNetwork;
 
-            makeExample = { system, hypervisor, config ? {} }:
-              lib.nixosSystem {
-                system = lib.replaceString "-darwin" "-linux" system;
+          isDarwinOnly = hypervisor: builtins.elem hypervisor hypervisorsDarwinOnly;
+          isDarwinSystem = system: lib.hasSuffix "-darwin" system;
+          hypervisorSupportsSystem = hypervisor: system:
+            if isDarwinSystem system
+            then builtins.elem hypervisor hypervisorsOnDarwin
+            else !(isDarwinOnly hypervisor);
 
-                modules = [
-                  self.nixosModules.microvm
-                  ({ lib, ... }: {
-                    system.stateVersion = lib.trivial.release;
+          makeExample = { system, hypervisor, config ? {} }:
+            lib.nixosSystem {
+              system = lib.replaceString "-darwin" "-linux" system;
 
-                    networking.hostName = "${hypervisor}-microvm";
-                    services.getty.autologinUser = "root";
+              modules = [
+                self.nixosModules.microvm
+                ({ lib, ... }: {
+                  system.stateVersion = lib.trivial.release;
 
-                    nixpkgs.overlays = [ self.overlay ];
-                    microvm = {
-                      inherit hypervisor;
-                      # share the host's /nix/store if the hypervisor supports it
-                      shares =
-                        if builtins.elem hypervisor hypervisorsWith9p then [{
-                          tag = "ro-store";
-                          source = "/nix/store";
-                          mountPoint = "/nix/.ro-store";
-                          proto = "9p";
-                        }]
-                        else if hypervisor == "vfkit" then [{
-                          tag = "ro-store";
-                          source = "/nix/store";
-                          mountPoint = "/nix/.ro-store";
-                          proto = "virtiofs";
-                        }]
-                        else [];
-                      # writableStoreOverlay = "/nix/.rw-store";
-                      # volumes = [ {
-                      #   image = "nix-store-overlay.img";
-                      #   mountPoint = config.microvm.writableStoreOverlay;
-                      #   size = 2048;
-                      # } ];
-                      interfaces = lib.optional (builtins.elem hypervisor hypervisorsWithUserNet) {
-                        type = "user";
-                        id = "qemu";
-                        mac = "02:00:00:01:01:01";
-                      };
-                      forwardPorts = lib.optional (hypervisor == "qemu") {
-                        host.port = 2222;
-                        guest.port = 22;
-                      };
-                      # Allow build on Darwin
-                      vmHostPackages = lib.mkIf (lib.hasSuffix "-darwin" system)
-                        nixpkgs.legacyPackages.${system};
+                  networking.hostName = "${hypervisor}-microvm";
+                  services.getty.autologinUser = "root";
+
+                  nixpkgs.overlays = [ self.overlay ];
+                  microvm = {
+                    inherit hypervisor;
+                    # share the host's /nix/store if the hypervisor supports it
+                    shares =
+                      if builtins.elem hypervisor hypervisorsWith9p then [{
+                        tag = "ro-store";
+                        source = "/nix/store";
+                        mountPoint = "/nix/.ro-store";
+                        proto = "9p";
+                      }]
+                      else if hypervisor == "vfkit" then [{
+                        tag = "ro-store";
+                        source = "/nix/store";
+                        mountPoint = "/nix/.ro-store";
+                        proto = "virtiofs";
+                      }]
+                      else [];
+                    # writableStoreOverlay = "/nix/.rw-store";
+                    # volumes = [ {
+                    #   image = "nix-store-overlay.img";
+                    #   mountPoint = config.microvm.writableStoreOverlay;
+                    #   size = 2048;
+                    # } ];
+                    interfaces = lib.optional (builtins.elem hypervisor hypervisorsWithUserNet) {
+                      type = "user";
+                      id = "qemu";
+                      mac = "02:00:00:01:01:01";
                     };
-                    networking.firewall.allowedTCPPorts = lib.optional (hypervisor == "qemu") 22;
-                    services.openssh = lib.optionalAttrs (hypervisor == "qemu") {
+                    forwardPorts = lib.optional (hypervisor == "qemu") {
+                      host.port = 2222;
+                      guest.port = 22;
+                    };
+                    # Allow build on Darwin
+                    vmHostPackages = lib.mkIf (lib.hasSuffix "-darwin" system)
+                      nixpkgs.legacyPackages.${system};
+                  };
+                  networking.firewall.allowedTCPPorts = lib.optional (hypervisor == "qemu") 22;
+                  services.openssh = lib.optionalAttrs (hypervisor == "qemu") {
+                    enable = true;
+                    settings.PermitRootLogin = "yes";
+                  };
+                })
+                config
+              ];
+            };
+
+          basicExamples = lib.flatten (
+            lib.map (system:
+              lib.map (hypervisor: {
+                name = "${system}-${hypervisor}-example";
+                value = makeExample { inherit system hypervisor; };
+                shouldInclude = hypervisorSupportsSystem hypervisor system;
+              }) self.lib.hypervisors
+            ) systems
+          );
+
+          tapExamples = lib.flatten (
+            lib.map (system:
+              lib.imap1 (idx: hypervisor: {
+                name = "${system}-${hypervisor}-example-with-tap";
+                value = makeExample {
+                  inherit system hypervisor;
+                  config = _: {
+                    microvm.interfaces = [ {
+                      type = "tap";
+                      id = "vm-${builtins.substring 0 4 hypervisor}";
+                      mac = "02:00:00:01:01:0${toString idx}";
+                    } ];
+                    networking = {
+                      interfaces.eth0.useDHCP = true;
+                      firewall.allowedTCPPorts = [ 22 ];
+                    };
+                    services.openssh = {
                       enable = true;
                       settings.PermitRootLogin = "yes";
                     };
-                  })
-                  config
-                ];
-              };
-
-            basicExamples = lib.flatten (
-              lib.map (system:
-                lib.map (hypervisor: {
-                  name = "${system}-${hypervisor}-example";
-                  value = makeExample { inherit system hypervisor; };
-                  shouldInclude = hypervisorSupportsSystem hypervisor system;
-                }) self.lib.hypervisors
-              ) systems
-            );
-
-            tapExamples = lib.flatten (
-              lib.map (system:
-                lib.imap1 (idx: hypervisor: {
-                  name = "${system}-${hypervisor}-example-with-tap";
-                  value = makeExample {
-                    inherit system hypervisor;
-                    config = _: {
-                      microvm.interfaces = [ {
-                        type = "tap";
-                        id = "vm-${builtins.substring 0 4 hypervisor}";
-                        mac = "02:00:00:01:01:0${toString idx}";
-                      } ];
-                      networking = {
-                        interfaces.eth0.useDHCP = true;
-                        firewall.allowedTCPPorts = [ 22 ];
-                      };
-                      services.openssh = {
-                        enable = true;
-                        settings.PermitRootLogin = "yes";
-                      };
-                    };
                   };
-                  shouldInclude = builtins.elem hypervisor hypervisorsWithTap
-                    && hypervisorSupportsSystem hypervisor system;
-                }) self.lib.hypervisors
-              ) systems
-            );
+                };
+                shouldInclude = builtins.elem hypervisor hypervisorsWithTap
+                  && hypervisorSupportsSystem hypervisor system;
+              }) self.lib.hypervisors
+            ) systems
+          );
 
-            included = builtins.filter (ex: ex.shouldInclude) (basicExamples ++ tapExamples);
-          in
-            builtins.listToAttrs (builtins.map ({ name, value, ... }: { inherit name value; }) included);
-      };
+          included = builtins.filter (ex: ex.shouldInclude) (basicExamples ++ tapExamples);
+        in
+          builtins.listToAttrs (builtins.map ({ name, value, ... }: { inherit name value; }) included);
+    };
 }


### PR DESCRIPTION
Hey, thanks for creating such a useful abstraction over VMs!

Would you be open to reducing the size of your dependency tree? `flake-utils` is only used for the `eachSystem` function. Inlining or replacing it cuts the project's lockfile in half (as `flake-utils` itself depends on another flake). 

All of these commits remove the external dependency in different ways; let me know if you would like me to amend or remove any of them:
- The first commit (57e124415ad00d4a229279da530c4de9bd815644) inline-vendors `forAllSystems`, including an MIT header. 
- The second commit (d5f82d04f34b0d4a568da6e3fe1eecd91f60250b) replaces it with a simpler function that retains parity. 
- The third commit (37af54cabdede37018ce26ddb34e63d0f4595084) removes the behavior of automatically including `currentSystem` if the flake is run with `--impure`. I'm guessing that most developers depending on `flake-utils` are unaware of this behavior – in my opinion explicitly relying on [`nix-systems`](https://github.com/nix-systems/nix-systems) for this behavior is a better way to achieve this goal.

While this PR aims to remove the external dependency on `flake-utils` in the simplest way possible, in the long term, I suggest [rewriting the flake with a `forAllSystems` function](https://ayats.org/blog/no-flake-utils#do-we-really-need-flake-utils) for better readability (you won't need to [merge two big attrsets](https://github.com/microvm-nix/microvm.nix/blob/5a18de0d3ff46971d2074c2326e45768b1a9de5f/flake.nix#L138), instead keeping it all top-level).