### PR TITLE
feat: add systemd-machined integration and SSH over VSOCK

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -1,6 +1,23 @@
 { self, nixpkgs, system }:
 
 let
+  inherit (nixpkgs) lib;
+
+  # Platform filtering for hypervisors
+  hypervisorsDarwinOnly = [ "vfkit" ];
+  hypervisorsOnDarwin = [ "qemu" "vfkit" ];
+  isDarwinOnly = hypervisor: builtins.elem hypervisor hypervisorsDarwinOnly;
+  isDarwinSystem = s: lib.hasSuffix "-darwin" s;
+  hypervisorSupportsSystem = hypervisor: s:
+    if isDarwinSystem s
+    then builtins.elem hypervisor hypervisorsOnDarwin
+    else !(isDarwinOnly hypervisor);
+
+  # Filter hypervisors to only those that support the current system
+  supportedHypervisors = builtins.filter
+    (hv: hypervisorSupportsSystem hv system)
+    self.lib.hypervisors;
+
   variants = [
     # hypervisor
     [ {
@@ -221,5 +238,6 @@ builtins.foldl' (result: hypervisor:
   in
     result //
     import ./vm.nix args //
-    import ./iperf.nix args
-) {} self.lib.hypervisors
+    import ./iperf.nix args //
+    import ./machined.nix args
+) {} supportedHypervisors

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -226,7 +226,8 @@ let
 
 in
 import ./shellcheck.nix args //
-
+import ./microvm-command.nix args //
+import ./imperative-template.nix args //
 import ./startup-shutdown.nix args //
 import ./shutdown-command.nix args //
 

--- a/checks/imperative-template.nix
+++ b/checks/imperative-template.nix
@@ -1,0 +1,50 @@
+{
+  self,
+  nixpkgs,
+  system,
+  ...
+}:
+
+{
+  imperative-template = import (nixpkgs + "/nixos/tests/make-test-python.nix") (_: {
+    name = "imperative-template";
+
+    nodes.host = {
+      imports = [ self.nixosModules.host ];
+      microvm.host.enable = true;
+    };
+
+    testScript = /* python */ ''
+      host.wait_for_unit("multi-user.target")
+
+      host.succeed("mkdir -p /var/lib/microvms/test/current/bin")
+      host.succeed("""cat > /var/lib/microvms/test/current/bin/microvm-run <<'EOF'
+      #!/bin/sh
+      trap 'exit 0' TERM INT
+      while true; do sleep 1; done
+      EOF
+      chmod +x /var/lib/microvms/test/current/bin/microvm-run
+      """)
+      host.succeed("""cat > /var/lib/microvms/test/current/bin/microvm-shutdown <<'EOF'
+      #!/bin/sh
+      exit 0
+      EOF
+      chmod +x /var/lib/microvms/test/current/bin/microvm-shutdown
+      """)
+      host.succeed("chown microvm:kvm -R /var/lib/microvms/")
+
+      # Should work in imperative mode without microvm-register/microvm-unregister scripts.
+      host.succeed("systemctl start microvm@test.service")
+      host.wait_for_unit("microvm@test.service")
+
+      host.succeed("systemctl stop microvm@test.service")
+      host.wait_until_succeeds("! systemctl is-active --quiet microvm@test.service")
+    '';
+
+    meta.timeout = 600;
+  })
+  {
+    inherit system;
+    pkgs = nixpkgs.legacyPackages.${system};
+  };
+}

--- a/checks/iperf.nix
+++ b/checks/iperf.nix
@@ -37,7 +37,7 @@ nixpkgs.lib.optionalAttrs (builtins.elem hypervisor self.lib.hypervisorsWithNetw
         };
       } "touch $out";
       environment.systemPackages = with pkgs; [ #with nixpkgs.legacyPackages.${system}; [
-        iperf iproute
+        iperf iproute2
       ];
       virtualisation = {
         # larger than the defaults

--- a/checks/machined.nix
+++ b/checks/machined.nix
@@ -1,0 +1,58 @@
+{ self, nixpkgs, system, hypervisor }:
+
+let
+  pkgs = nixpkgs.legacyPackages.${system};
+  vmName = "machined-test";
+in
+{
+  # Test that MicroVMs can be registered with systemd-machined
+  "machined-${hypervisor}" = pkgs.nixosTest {
+    name = "machined-${hypervisor}";
+    nodes.host = { lib, ... }: {
+      imports = [ self.nixosModules.host ];
+
+      virtualisation.qemu.options = [
+        "-cpu"
+        {
+          "aarch64-linux" = "cortex-a72";
+          "x86_64-linux" = "kvm64,+svm,+vmx";
+        }.${system}
+      ];
+      virtualisation.diskSize = 4096;
+
+      # Define a VM with machined registration enabled
+      microvm.vms.${vmName}.config = {
+        microvm = {
+          hypervisor = hypervisor;
+          # Enable machined registration on the VM
+          registerWithMachined = true;
+        };
+        networking.hostName = vmName;
+        system.stateVersion = lib.trivial.release;
+      };
+    };
+    testScript = ''
+      # Wait for the MicroVM service to start
+      host.wait_for_unit("microvm@${vmName}.service", timeout = 1200)
+
+      # Verify the VM is registered with machined
+      host.succeed("machinectl list | grep -q '${vmName}'")
+
+      # Verify machine status works
+      host.succeed("machinectl status '${vmName}'")
+
+      # Verify the machine class is 'vm'
+      host.succeed("machinectl show '${vmName}' --property=Class | grep -q 'vm'")
+
+      # Verify leader PID exists
+      host.succeed("machinectl show '${vmName}' --property=Leader | grep -q '^Leader=[0-9]'")
+
+      # Terminate the VM via machinectl (sends SIGTERM to hypervisor)
+      host.succeed("machinectl terminate '${vmName}'")
+
+      # Wait for the service to stop
+      host.wait_until_fails("machinectl status '${vmName}'", timeout = 30)
+    '';
+    meta.timeout = 1800;
+  };
+}

--- a/checks/machined.nix
+++ b/checks/machined.nix
@@ -1,58 +1,80 @@
 { self, nixpkgs, system, hypervisor }:
 
 let
-  pkgs = nixpkgs.legacyPackages.${system};
   vmName = "machined-test";
+  vsockCid = 4242;
 in
 {
   # Test that MicroVMs can be registered with systemd-machined
-  "machined-${hypervisor}" = pkgs.nixosTest {
-    name = "machined-${hypervisor}";
-    nodes.host = { lib, ... }: {
-      imports = [ self.nixosModules.host ];
-
-      virtualisation.qemu.options = [
-        "-cpu"
+  "machined-${hypervisor}" =
+    import (nixpkgs + "/nixos/tests/make-test-python.nix")
+      (
+        { pkgs, lib, ... }:
         {
-          "aarch64-linux" = "cortex-a72";
-          "x86_64-linux" = "kvm64,+svm,+vmx";
-        }.${system}
-      ];
-      virtualisation.diskSize = 4096;
+          name = "machined-${hypervisor}";
+          nodes.host = {
+            imports = [ self.nixosModules.host ];
 
-      # Define a VM with machined registration enabled
-      microvm.vms.${vmName}.config = {
-        microvm = {
-          hypervisor = hypervisor;
-          # Enable machined registration on the VM
-          registerWithMachined = true;
-        };
-        networking.hostName = vmName;
-        system.stateVersion = lib.trivial.release;
+            boot.kernelModules = [ "kvm" ];
+
+            virtualisation.qemu.options = [
+              "-cpu"
+              {
+                "aarch64-linux" = "cortex-a72";
+                "x86_64-linux" = "kvm64,+svm,+vmx";
+              }
+              .${system}
+            ];
+            virtualisation.diskSize = 4096;
+
+            # Define a VM with machined registration enabled
+            microvm.vms.${vmName}.config = {
+              microvm = {
+                inherit hypervisor;
+                # Enable machined registration on the VM
+                registerWithMachined = true;
+              }
+              // lib.optionalAttrs (hypervisor != "cloud-hypervisor") {
+                vsock.cid = vsockCid;
+              };
+              networking.hostName = vmName;
+              system.stateVersion = lib.trivial.release;
+            };
+          };
+          testScript = ''
+            # Wait for the MicroVM service to start
+            host.wait_for_unit("microvm@${vmName}.service", timeout = 60)
+            # ^ this is actually none blocking
+
+            # Verify the VM is registered with machined
+            host.wait_until_succeeds("machinectl list | grep -q '${vmName}'", timeout=240)
+
+            # Verify machine status works
+            host.succeed("machinectl status '${vmName}'")
+
+            # Verify the machine class is 'vm'
+            host.succeed("machinectl show '${vmName}' --property=Class | grep -q 'vm'")
+
+            ${lib.optionalString ((lib.versionAtLeast pkgs.systemd.version "259") && hypervisor != "cloud-hypervisor") ''
+              # On systemd >=259 RegisterMachineEx path should expose VSOCK/SSH metadata
+              host.succeed("machinectl show '${vmName}' --property=VSockCID | grep -q 'VSockCID=${toString vsockCid}'")
+              host.succeed("machinectl show '${vmName}' --property=SSHAddress | grep -q 'SSHAddress=vsock/${toString vsockCid}'")
+            ''}
+
+            # Test kill command (send signal 0 to check process exists)
+            host.succeed("machinectl kill '${vmName}' --signal=0")
+
+            # Terminate the VM via machinectl (sends SIGTERM to hypervisor)
+            host.succeed("machinectl terminate '${vmName}'")
+
+            # Wait for the service to stop
+            host.wait_until_fails("machinectl status '${vmName}'", timeout = 30)
+          '';
+          meta.timeout = 600;
+        }
+      )
+      {
+        inherit system;
+        pkgs = nixpkgs.legacyPackages.${system};
       };
-    };
-    testScript = ''
-      # Wait for the MicroVM service to start
-      host.wait_for_unit("microvm@${vmName}.service", timeout = 1200)
-
-      # Verify the VM is registered with machined
-      host.succeed("machinectl list | grep -q '${vmName}'")
-
-      # Verify machine status works
-      host.succeed("machinectl status '${vmName}'")
-
-      # Verify the machine class is 'vm'
-      host.succeed("machinectl show '${vmName}' --property=Class | grep -q 'vm'")
-
-      # Verify leader PID exists
-      host.succeed("machinectl show '${vmName}' --property=Leader | grep -q '^Leader=[0-9]'")
-
-      # Terminate the VM via machinectl (sends SIGTERM to hypervisor)
-      host.succeed("machinectl terminate '${vmName}'")
-
-      # Wait for the service to stop
-      host.wait_until_fails("machinectl status '${vmName}'", timeout = 30)
-    '';
-    meta.timeout = 1800;
-  };
 }

--- a/checks/machined.nix
+++ b/checks/machined.nix
@@ -61,9 +61,6 @@ in
               host.succeed("machinectl show '${vmName}' --property=SSHAddress | grep -q 'SSHAddress=vsock/${toString vsockCid}'")
             ''}
 
-            # Test kill command (send signal 0 to check process exists)
-            host.succeed("machinectl kill '${vmName}' --signal=0")
-
             # Terminate the VM via machinectl (sends SIGTERM to hypervisor)
             host.succeed("machinectl terminate '${vmName}'")
 

--- a/checks/microvm-command.nix
+++ b/checks/microvm-command.nix
@@ -1,0 +1,77 @@
+{ nixpkgs, system, ... }:
+
+let
+  pkgs = nixpkgs.legacyPackages.${system};
+
+  fakeOpenSSH = pkgs.writeShellScriptBin "ssh" ''
+    #!/bin/sh
+    out="''${SSH_ARGS_OUT:?SSH_ARGS_OUT must be set}"
+    : > "$out"
+    for arg in "$@"; do
+      printf '%s\n' "$arg" >> "$out"
+    done
+  '';
+
+  fakeSystemctl = pkgs.writeShellScriptBin "systemctl" ''
+    if [[ $1 == is-active ]]; then
+      exit 0
+    else
+      exit 1
+    fi
+  '';
+
+  microvmCommand = pkgs.callPackage ../pkgs/microvm-command.nix {
+    openssh = fakeOpenSSH;
+    stateDir = "/tmp/microvms";
+  };
+in
+{
+  microvm-command =
+    pkgs.runCommandLocal "microvm-command"
+      {
+        nativeBuildInputs = [
+          microvmCommand
+          pkgs.diffutils
+          fakeSystemctl
+        ];
+      }
+      ''
+        set -euo pipefail
+
+        mkdir -p /tmp/microvms/vm/current/share/microvm
+        echo 4242 > /tmp/microvms/vm/current/share/microvm/vsock-cid
+        echo qemu > /tmp/microvms/vm/current/share/microvm/hypervisor
+
+        export SSH_ARGS_OUT="$PWD/ssh-args-extra-opts"
+        microvm -s vm -- -l root -i /tmp/test-key
+        cat > "$PWD/expected-extra-opts" <<'EOF'
+        -o
+        StrictHostKeyChecking=no
+        -o
+        UserKnownHostsFile=/dev/null
+        vsock/4242
+        -l
+        root
+        -i
+        /tmp/test-key
+        EOF
+        diff -u "$PWD/expected-extra-opts" "$PWD/ssh-args-extra-opts"
+
+        export SSH_ARGS_OUT="$PWD/ssh-args-remote-cmd"
+        microvm -s vm uname -a
+        cat > "$PWD/expected-remote-cmd" <<'EOF'
+        -o
+        StrictHostKeyChecking=no
+        -o
+        UserKnownHostsFile=/dev/null
+        vsock/4242
+        -l
+        root
+        uname
+        -a
+        EOF
+        diff -u "$PWD/expected-remote-cmd" "$PWD/ssh-args-remote-cmd"
+
+        mkdir $out
+      '';
+}

--- a/doc/book.toml
+++ b/doc/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Astro"]
 language = "en"
-multilingual = false
 src = "src"
 title = "microvm.nix"
 

--- a/doc/src/faq.md
+++ b/doc/src/faq.md
@@ -17,17 +17,7 @@ Let us know if you know more!
 
 That is possible without even requiring a network transport by just
 making the journals available to the host as a share. Because journald
-identifies hosts by their `/etc/machine-id`, we propose to use static
-content for that file. Add a NixOS module like the following to your
-MicroVM configuration:
-
-```nix
-environment.etc."machine-id" = {
-  mode = "0644";
-  text =
-    # change this to suit your flake's interface
-    self.lib.addresses.machineId.${config.networking.hostName} + "\n";
-};
+identifies hosts by their `/etc/machine-id`, the `microvm.machineId` should be set.
 
 microvm.shares = [ {
   # On the host

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "lastModified": 1772773019,
+        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1759482047,
-        "narHash": "sha256-H1wiXRQHxxPyMMlP39ce3ROKCwI5/tUn36P8x6dFiiQ=",
+        "lastModified": 1772189877,
+        "narHash": "sha256-i1p90Rgssb//aNiTDFq46ZG/fk3LmyRLChtp/9lddyA=",
         "ref": "refs/heads/main",
-        "rev": "c5d5786d3dc938af0b279c542d1e43bce381b4b9",
-        "revCount": 996,
+        "rev": "fe39e122d898f66e89ffa17d4f4209989ccb5358",
+        "revCount": 1255,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -85,9 +85,7 @@
         in {
           build-microvm = pkgs.callPackage ./pkgs/build-microvm.nix { inherit self; };
           doc = pkgs.callPackage ./pkgs/doc.nix { };
-          microvm = import ./pkgs/microvm-command.nix {
-            pkgs = import nixpkgs { inherit system; };
-          };
+          microvm = pkgs.callPackage ./pkgs/microvm-command.nix { };
           # all compilation-heavy packages that shall be prebuilt for a binary cache
           prebuilt = pkgs.buildEnv {
             name = "prebuilt";

--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,7 @@
 
       # Takes too much memory in `nix flake show`
       # checks = forAllSystems (system:
-      #   import ./checks { inherit self nixpkgs system; };
+      #   import ./checks { inherit self nixpkgs system; }
       # );
 
       # hydraJobs are checks

--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -6,7 +6,7 @@
 let
   inherit (pkgs) lib;
 
-  inherit (microvmConfig) hostName machineId vmHostPackages;
+  inherit (microvmConfig) hostName vmHostPackages;
 
   inherit (import ./. { inherit lib; }) makeMacvtap withDriveLetters extractOptValues extractParamValue;
   inherit (import ./volumes.nix { pkgs = microvmConfig.vmHostPackages; }) createVolumesScript;
@@ -24,13 +24,23 @@ let
   tapMultiQueue = hypervisorConfig.tapMultiQueue or false;
   setBalloonScript = hypervisorConfig.setBalloonScript or null;
 
-  execArg = lib.optionalString microvmConfig.prettyProcnames
-    ''-a "microvm@${hostName}"'';
-
+  execArg = lib.optionalString microvmConfig.prettyProcnames ''-a "microvm@${hostName}"'';
 
   # TAP interface names for machined registration
   tapInterfaces = lib.filter (i: i.type == "tap" && i ? id) microvmConfig.interfaces;
   tapInterfaceNames = map (i: i.id) tapInterfaces;
+
+  # Generate machine UUID at eval time for consistency across SMBIOS and machined
+  # Uses provided machineId or generates UUIDv5 from hostname
+  machineUuid =
+    if microvmConfig.machineId != null then
+      microvmConfig.machineId
+    else
+      builtins.readFile (
+        vmHostPackages.runCommand "machine-uuid" { } ''
+          ${vmHostPackages.python3}/bin/python3 -c 'import uuid; print(uuid.uuid5(uuid.NAMESPACE_DNS, "${hostName}"), end="")' > $out
+        ''
+      );
 
   # Script to unregister from systemd-machined
   unregisterMachineScript = ''
@@ -43,88 +53,148 @@ let
       /org/freedesktop/machine1 \
       org.freedesktop.machine1.Manager \
       TerminateMachine "s" \
-      "$MACHINE_NAME" 2>/dev/null
+      "$MACHINE_NAME" 2>/dev/null || true
   '';
 
   # Script to register with systemd-machined
   # Note: NSS hostname resolution (ssh $vmname) doesn't work for VMs, only containers.
   # machined's GetAddresses method requires container namespaces to enumerate IPs.
-  # Future: systemd 259+ adds RegisterMachineEx which supports SSHAddress property
-  # for VMs, enabling `machinectl ssh` and potentially NSS resolution.
   registerMachineScript = ''
     set -euo pipefail
 
     LEADER_PID="''${1:-$$}"
     MACHINE_NAME="${hostName}"
-    UUID="${machineId}"
-    PATH=${lib.makeBinPath (with vmHostPackages; [ coreutils gnused gawk systemd ])}
+    UUID="${machineUuid}"
 
-    # Convert UUID to space-separated decimal bytes for busctl
-    UUID_BYTES=$(echo "$UUID" | tr -d '-' | sed 's/../0x& /g' | awk '{for(i=1;i<=NF;i++) printf "%d ", strtonum($i)}')
+    # Convert UUID to decimal bytes for busctl array arguments
+    UUID_BYTES=$(echo "$UUID" | tr -d '-' | ${vmHostPackages.gnused}/bin/sed 's/../0x& /g' | ${vmHostPackages.gawk}/bin/awk '{for(i=1;i<=NF;i++) printf "%d ", strtonum($i)}')
+    read -r -a UUID_BYTE_ARRAY <<< "$UUID_BYTES"
 
-    '' + (if tapInterfaceNames == [] then ''
-    # No TAP interfaces, use simple RegisterMachine
-    busctl call org.freedesktop.machine1 /org/freedesktop/machine1 \
-      org.freedesktop.machine1.Manager RegisterMachine "sayssus" \
-      "$MACHINE_NAME" 16 $UUID_BYTES "microvm.nix" "vm" $LEADER_PID "/"
-    '' else ''
-    # Build network interface index array for RegisterMachineWithNetwork
-    IFINDICES=""
-    '' + lib.concatMapStrings (name: ''
-    if [ -e /sys/class/net/${name}/ifindex ]; then
-      IFINDICES="$IFINDICES $(cat /sys/class/net/${name}/ifindex)"
-    fi
-    '') tapInterfaceNames + ''
+    IFINDEX_ARRAY=()
+    ${lib.concatMapStrings (name: ''
+      if [ -e /sys/class/net/${name}/ifindex ]; then
+        IFINDEX_ARRAY+=("$(cat /sys/class/net/${name}/ifindex)")
+      fi
+    '') tapInterfaceNames}
+    NUM_IFS=''${#IFINDEX_ARRAY[@]}
 
-    # Count interfaces
-    NUM_IFS=$(echo $IFINDICES | wc -w)
+    ${lib.optionalString
+      (microvmConfig.vsock.cid != null && microvmConfig.hypervisor != "cloud-hypervisor")
+      ''
+        VSOCK_CID=${toString microvmConfig.vsock.cid}
+        SSH_ADDRESS="vsock/${toString microvmConfig.vsock.cid}"
+      ''
+    }
 
-    if [ "$NUM_IFS" -gt 0 ]; then
-      # Use RegisterMachineWithNetwork with TAP interfaces
-      busctl call org.freedesktop.machine1 /org/freedesktop/machine1 \
-        org.freedesktop.machine1.Manager RegisterMachineWithNetwork "sayssusai" \
-        "$MACHINE_NAME" 16 $UUID_BYTES "microvm.nix" "vm" $LEADER_PID "/" $NUM_IFS $IFINDICES
-    else
-      # Fallback to simple RegisterMachine
-      busctl call org.freedesktop.machine1 /org/freedesktop/machine1 \
-        org.freedesktop.machine1.Manager RegisterMachine "sayssus" \
-        "$MACHINE_NAME" 16 $UUID_BYTES "microvm.nix" "vm" $LEADER_PID "/"
-    fi
-    '');
+    MANAGER_INTROSPECT=$(${vmHostPackages.systemd}/bin/busctl introspect \
+      org.freedesktop.machine1 \
+      /org/freedesktop/machine1 \
+      org.freedesktop.machine1.Manager 2>/dev/null || true)
 
-  binScripts = microvmConfig.binScripts // {
-    microvm-run = ''
-      set -eou pipefail
-      ${preStart}
-      ${createVolumesScript microvmConfig.volumes}
-      ${lib.optionalString (hypervisorConfig.requiresMacvtapAsFds or false) openMacvtapFds}
-      runtime_args=${lib.optionalString (microvmConfig.extraArgsScript != null) ''
-        $(${microvmConfig.extraArgsScript})
-      ''}
+    if [[ "$MANAGER_INTROSPECT" == *"RegisterMachineEx"* ]]; then
+      # systemd 259+: use extensible registration for VSOCK/SSH metadata
+      EX_PROP_COUNT=5
+      EX_ARGS=(
+        "$MACHINE_NAME"
+        "$EX_PROP_COUNT"
+        "Id" "ay" ''${#UUID_BYTE_ARRAY[@]} "''${UUID_BYTE_ARRAY[@]}"
+        "Service" "s" "microvm.nix"
+        "Class" "s" "vm"
+        "LeaderPID" "u" "$LEADER_PID"
+        "RootDirectory" "s" "/"
+      )
 
-      exec ${execArg} ${command} ''${runtime_args:-}
-    '';
-  } // lib.optionalAttrs canShutdown {
-    microvm-shutdown = shutdownCommand;
-  } // lib.optionalAttrs (setBalloonScript != null) {
-    microvm-balloon = ''
-      set -e
-
-      if [ -z "$1" ]; then
-        echo "Usage: $0 <balloon-size-mb>"
-        exit 1
+      if [ -n "''${VSOCK_CID:-}" ]; then
+        EX_PROP_COUNT=$((EX_PROP_COUNT + 1))
+        EX_ARGS+=("VSockCID" "u" "$VSOCK_CID")
       fi
 
-      SIZE=$1
-      ${setBalloonScript}
-    '';
-  } // lib.optionalAttrs microvmConfig.registerWithMachined {
-    microvm-register = registerMachineScript;
-    microvm-unregister = unregisterMachineScript;
-  };
+      if [ -n "''${SSH_ADDRESS:-}" ]; then
+        EX_PROP_COUNT=$((EX_PROP_COUNT + 1))
+        EX_ARGS+=("SSHAddress" "s" "$SSH_ADDRESS")
+      fi
 
-  binScriptPkgs = lib.mapAttrs (scriptName: lines:
-    vmHostPackages.writeShellScript "microvm-${hostName}-${scriptName}" lines
+      if [ "$NUM_IFS" -gt 0 ]; then
+        EX_PROP_COUNT=$((EX_PROP_COUNT + 1))
+        EX_ARGS+=("NetworkInterfaces" "ai" "$NUM_IFS" "''${IFINDEX_ARRAY[@]}")
+      fi
+
+      EX_ARGS[1]="$EX_PROP_COUNT"
+
+      ${vmHostPackages.systemd}/bin/busctl call \
+        org.freedesktop.machine1 \
+        /org/freedesktop/machine1 \
+        org.freedesktop.machine1.Manager \
+        RegisterMachineEx "sa(sv)" \
+        "''${EX_ARGS[@]}"
+    elif [ "$NUM_IFS" -gt 0 ]; then
+      ${vmHostPackages.systemd}/bin/busctl call \
+        org.freedesktop.machine1 \
+        /org/freedesktop/machine1 \
+        org.freedesktop.machine1.Manager \
+        RegisterMachineWithNetwork "sayssusai" \
+        "$MACHINE_NAME" \
+        ''${#UUID_BYTE_ARRAY[@]} "''${UUID_BYTE_ARRAY[@]}" \
+        "microvm.nix" \
+        "vm" \
+        "$LEADER_PID" \
+        "/" \
+        "$NUM_IFS" "''${IFINDEX_ARRAY[@]}"
+    else
+      ${vmHostPackages.systemd}/bin/busctl call \
+        org.freedesktop.machine1 \
+        /org/freedesktop/machine1 \
+        org.freedesktop.machine1.Manager \
+        RegisterMachine "sayssus" \
+        "$MACHINE_NAME" \
+        ''${#UUID_BYTE_ARRAY[@]} "''${UUID_BYTE_ARRAY[@]}" \
+        "microvm.nix" \
+        "vm" \
+        "$LEADER_PID" \
+        "/"
+    fi
+  '';
+
+  binScripts =
+    microvmConfig.binScripts
+    // {
+      microvm-run = ''
+        set -eou pipefail
+        ${preStart}
+        ${createVolumesScript microvmConfig.volumes}
+        ${lib.optionalString (hypervisorConfig.requiresMacvtapAsFds or false) openMacvtapFds}
+        runtime_args=${
+          lib.optionalString (microvmConfig.extraArgsScript != null) ''
+            $(${microvmConfig.extraArgsScript})
+          ''
+        }
+
+        exec ${execArg} ${command} ''${runtime_args:-}
+      '';
+    }
+    // lib.optionalAttrs canShutdown {
+      microvm-shutdown = shutdownCommand;
+    }
+    // lib.optionalAttrs (setBalloonScript != null) {
+      microvm-balloon = ''
+        set -e
+
+        if [ -z "$1" ]; then
+          echo "Usage: $0 <balloon-size-mb>"
+          exit 1
+        fi
+
+        SIZE=$1
+        ${setBalloonScript}
+      '';
+    }
+    // lib.optionalAttrs microvmConfig.registerWithMachined {
+      microvm-register = registerMachineScript;
+      microvm-unregister = unregisterMachineScript;
+    };
+
+  binScriptPkgs = lib.mapAttrs (
+    scriptName: lines: vmHostPackages.writeShellScript "microvm-${hostName}-${scriptName}" lines
   ) binScripts;
 in
 

--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -100,7 +100,7 @@ let
         "Id" "ay" ''${#UUID_BYTE_ARRAY[@]} "''${UUID_BYTE_ARRAY[@]}"
         "Service" "s" "microvm.nix"
         "Class" "s" "vm"
-        "LeaderPID" "u" "$LEADER_PID"
+        "LeaderPIDFD" "h" "PIDFD"
         "RootDirectory" "s" "/"
       )
 
@@ -121,12 +121,23 @@ let
 
       EX_ARGS[1]="$EX_PROP_COUNT"
 
-      ${vmHostPackages.systemd}/bin/busctl call \
+      # This is our very poor mans method to get around upstream pid recycling safety features :)
+      ${lib.getExe vmHostPackages.python3} - \
+        ${vmHostPackages.systemd}/bin/busctl call \
         org.freedesktop.machine1 \
         /org/freedesktop/machine1 \
         org.freedesktop.machine1.Manager \
         RegisterMachineEx "sa(sv)" \
-        "''${EX_ARGS[@]}"
+        "''${EX_ARGS[@]}" \
+        <<EOF
+    import os; import subprocess; import sys
+    try:
+      pidfd = os.pidfd_open($LEADER_PID, 0)
+    except AttributeError:
+      print("Error: Which NixOS version are you running that pidfd_open syscall is not available?!")
+      exit(1)
+    subprocess.run([str(pidfd) if x == 'PIDFD' else x for x in sys.argv[1:]], pass_fds=[pidfd])
+    EOF
     elif [ "$NUM_IFS" -gt 0 ]; then
       ${vmHostPackages.systemd}/bin/busctl call \
         org.freedesktop.machine1 \

--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -6,7 +6,7 @@
 let
   inherit (pkgs) lib;
 
-  inherit (microvmConfig) hostName vmHostPackages;
+  inherit (microvmConfig) hostName machineId vmHostPackages;
 
   inherit (import ./. { inherit lib; }) makeMacvtap withDriveLetters extractOptValues extractParamValue;
   inherit (import ./volumes.nix { pkgs = microvmConfig.vmHostPackages; }) createVolumesScript;
@@ -27,6 +27,70 @@ let
   execArg = lib.optionalString microvmConfig.prettyProcnames
     ''-a "microvm@${hostName}"'';
 
+
+  # TAP interface names for machined registration
+  tapInterfaces = lib.filter (i: i.type == "tap" && i ? id) microvmConfig.interfaces;
+  tapInterfaceNames = map (i: i.id) tapInterfaces;
+
+  # Script to unregister from systemd-machined
+  unregisterMachineScript = ''
+    set -euo pipefail
+    MACHINE_NAME="${hostName}"
+
+    # Terminate the machine registration (ignore errors if already gone)
+    ${vmHostPackages.systemd}/bin/busctl call \
+      org.freedesktop.machine1 \
+      /org/freedesktop/machine1 \
+      org.freedesktop.machine1.Manager \
+      TerminateMachine "s" \
+      "$MACHINE_NAME" 2>/dev/null
+  '';
+
+  # Script to register with systemd-machined
+  # Note: NSS hostname resolution (ssh $vmname) doesn't work for VMs, only containers.
+  # machined's GetAddresses method requires container namespaces to enumerate IPs.
+  # Future: systemd 259+ adds RegisterMachineEx which supports SSHAddress property
+  # for VMs, enabling `machinectl ssh` and potentially NSS resolution.
+  registerMachineScript = ''
+    set -euo pipefail
+
+    LEADER_PID="''${1:-$$}"
+    MACHINE_NAME="${hostName}"
+    UUID="${machineId}"
+    PATH=${lib.makeBinPath (with vmHostPackages; [ coreutils gnused gawk systemd ])}
+
+    # Convert UUID to space-separated decimal bytes for busctl
+    UUID_BYTES=$(echo "$UUID" | tr -d '-' | sed 's/../0x& /g' | awk '{for(i=1;i<=NF;i++) printf "%d ", strtonum($i)}')
+
+    '' + (if tapInterfaceNames == [] then ''
+    # No TAP interfaces, use simple RegisterMachine
+    busctl call org.freedesktop.machine1 /org/freedesktop/machine1 \
+      org.freedesktop.machine1.Manager RegisterMachine "sayssus" \
+      "$MACHINE_NAME" 16 $UUID_BYTES "microvm.nix" "vm" $LEADER_PID "/"
+    '' else ''
+    # Build network interface index array for RegisterMachineWithNetwork
+    IFINDICES=""
+    '' + lib.concatMapStrings (name: ''
+    if [ -e /sys/class/net/${name}/ifindex ]; then
+      IFINDICES="$IFINDICES $(cat /sys/class/net/${name}/ifindex)"
+    fi
+    '') tapInterfaceNames + ''
+
+    # Count interfaces
+    NUM_IFS=$(echo $IFINDICES | wc -w)
+
+    if [ "$NUM_IFS" -gt 0 ]; then
+      # Use RegisterMachineWithNetwork with TAP interfaces
+      busctl call org.freedesktop.machine1 /org/freedesktop/machine1 \
+        org.freedesktop.machine1.Manager RegisterMachineWithNetwork "sayssusai" \
+        "$MACHINE_NAME" 16 $UUID_BYTES "microvm.nix" "vm" $LEADER_PID "/" $NUM_IFS $IFINDICES
+    else
+      # Fallback to simple RegisterMachine
+      busctl call org.freedesktop.machine1 /org/freedesktop/machine1 \
+        org.freedesktop.machine1.Manager RegisterMachine "sayssus" \
+        "$MACHINE_NAME" 16 $UUID_BYTES "microvm.nix" "vm" $LEADER_PID "/"
+    fi
+    '');
 
   binScripts = microvmConfig.binScripts // {
     microvm-run = ''
@@ -54,6 +118,9 @@ let
       SIZE=$1
       ${setBalloonScript}
     '';
+  } // lib.optionalAttrs microvmConfig.registerWithMachined {
+    microvm-register = registerMachineScript;
+    microvm-unregister = unregisterMachineScript;
   };
 
   binScriptPkgs = lib.mapAttrs (scriptName: lines:
@@ -67,7 +134,7 @@ vmHostPackages.buildPackages.runCommand "microvm-${microvmConfig.hypervisor}-${h
   meta.mainProgram = "microvm-run";
   passthru = {
     inherit canShutdown supportsNotifySocket tapMultiQueue;
-    inherit (microvmConfig) hypervisor;
+    inherit (microvmConfig) hypervisor registerWithMachined machineId;
   };
 } ''
   mkdir -p $out/bin
@@ -117,4 +184,10 @@ vmHostPackages.buildPackages.runCommand "microvm-${microvmConfig.hypervisor}-${h
   ${lib.concatMapStrings ({ bus, path, ... }: ''
     echo "${path}" >> $out/share/microvm/${bus}-devices
   '') microvmConfig.devices}
+
+  # VSOCK info for ssh access
+  ${lib.optionalString (microvmConfig.vsock.cid != null) ''
+    echo "${toString microvmConfig.vsock.cid}" > $out/share/microvm/vsock-cid
+  ''}
+  echo "${microvmConfig.hypervisor}" > $out/share/microvm/hypervisor
 ''

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -37,9 +37,8 @@ let
     then "io_uring"
     else "threads";
 
-  inherit (microvmConfig) hostName vcpu mem balloon initialBalloonMem deflateOnOOM hotplugMem hotpluggedMem user interfaces shares socket forwardPorts devices vsock graphics storeOnDisk kernel initrdPath storeDisk credentialFiles;
+  inherit (microvmConfig) hostName machineId vcpu mem balloon initialBalloonMem deflateOnOOM hotplugMem hotpluggedMem user interfaces shares socket forwardPorts devices vsock graphics storeOnDisk kernel initrdPath storeDisk credentialFiles;
   inherit (microvmConfig.qemu) machine extraArgs serialConsole pcieRootPorts;
-
 
   volumes = withDriveLetters microvmConfig;
 
@@ -182,6 +181,8 @@ lib.warnIf (mem == 2048) ''
 
       "-chardev" "stdio,id=stdio,signal=off"
       "-device" "virtio-rng-${devType}"
+    ] ++ lib.optionals (machineId != null) [
+      "-smbios" "type=1,uuid=${machineId}"
     ] ++
       # Create PCIe root ports before vfio-pci devices that might require them
       builtins.concatMap ({ id, bus, chassis, slot, addr, ... }:
@@ -351,6 +352,11 @@ lib.warnIf (mem == 2048) ''
     if socket != null
     then
       ''
+        # Exit gracefully if QEMU is already gone (e.g., killed by machinectl)
+        if [ ! -S ${socket} ]; then
+          exit 0
+        fi
+
         (
           ${writeQmp { execute = "qmp_capabilities"; }}
           ${writeQmp {

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -1,4 +1,9 @@
-{ pkgs, config, lib, ... }:
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
 let
   inherit (config.microvm) stateDir;
   microvmCommand = pkgs.callPackage ../../pkgs/microvm-command.nix {
@@ -127,12 +132,6 @@ in
         after = lib.optionals runner.registerWithMachined [
           "systemd-machined.service"
         ];
-        serviceConfig.ExecStartPost = lib.optionals runner.registerWithMachined [
-          "+${stateDir}/${name}/current/bin/microvm-register $MAINPID"
-        ];
-        serviceConfig.ExecStopPost = lib.optionals runner.registerWithMachined [
-          "+${stateDir}/${name}/current/bin/microvm-unregister"
-        ];
       };
       "microvm-tap-interfaces@${name}" = {
         serviceConfig.X-RestartIfChanged = [ "" microvmConfig.restartIfChanged ];
@@ -249,6 +248,7 @@ in
         ];
         after = [
           "network.target"
+          "systemd-modules-load.service"
           "microvm-tap-interfaces@%i.service"
           "microvm-macvtap-interfaces@%i.service"
           "microvm-pci-devices@%i.service"
@@ -265,6 +265,12 @@ in
           WorkingDirectory = "${stateDir}/%i";
           ExecStart = "${stateDir}/%i/current/bin/microvm-run";
           ExecStop = "${stateDir}/%i/booted/bin/microvm-shutdown";
+          ExecStartPost = [
+            "+${pkgs.runtimeShell} -c 'if [ -x ${stateDir}/%i/current/bin/microvm-register ]; then ${stateDir}/%i/current/bin/microvm-register $MAINPID; fi'"
+          ];
+          ExecStopPost = [
+            "+${pkgs.runtimeShell} -c 'if [ -x ${stateDir}/%i/current/bin/microvm-unregister ]; then ${stateDir}/%i/current/bin/microvm-unregister; fi'"
+          ];
           TimeoutSec = config.microvm.host.startupTimeout;
           Restart = "always";
           RestartSec = "5s";

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -1,8 +1,8 @@
 { pkgs, config, lib, ... }:
 let
   inherit (config.microvm) stateDir;
-  microvmCommand = import ../../pkgs/microvm-command.nix {
-    inherit pkgs stateDir;
+  microvmCommand = pkgs.callPackage ../../pkgs/microvm-command.nix {
+    inherit stateDir;
   };
   user = "microvm";
   group = "kvm";

--- a/nixos-modules/microvm/default.nix
+++ b/nixos-modules/microvm/default.nix
@@ -22,6 +22,7 @@ in
     ./rosetta.nix
     ./optimization.nix
     ./ssh-deploy.nix
+    ./vsock-ssh.nix
   ];
 
   config = {

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -486,6 +486,51 @@ in
       '';
     };
 
+    registerWithMachined = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Register this MicroVM with systemd-machined on the host, enabling management via machinectl.
+
+        When enabled, a registration script is generated in the runner package. The host module will call this
+        script after the hypervisor starts. The VM is registered with class "vm" using the UUID from `machineId`
+        (or a deterministic UUID derived from hostname).
+
+        Supported machinectl commands:
+        - `list`, `status`, `show` - VM visibility
+        - `terminate`, `kill` - stop VM (will auto-restart if Restart=always)
+
+        Note: `machinectl reboot` stops the VM but won't auto-restart it because systemd treats it as an
+        intentional stop. Use `systemctl restart microvm@<name>` for restarts.
+      '';
+    };
+
+    machineId = mkOption {
+      type = with types; nullOr str;
+      default =
+        let
+          hash = builtins.hashString "sha256" "microvm.nix:${hostName}";
+          hs = offset: len:
+            builtins.substring offset len hash;
+        in builtins.concatStringsSep "-" [
+          (hs 0 8)
+          (hs 8 4)
+          (hs 12 4)
+          (hs 16 4)
+          (hs 20 12)
+        ];
+      example = "a67472e5-570e-5c8a-b18c-ae3c77701050";
+      description = ''
+        UUID for this MicroVM, used for:
+        - Registration with systemd-machined
+        - SMBIOS system UUID (QEMU only)
+        - Guest /etc/machine-id initialization
+
+        If null, a deterministic UUIDv5 is generated from the hostname.
+        Format: 8-4-4-4-12 hex digits (standard UUID format).
+      '';
+    };
+
     kernelParams = mkOption {
       type = with types; listOf str;
       description = "Includes boot.kernelParams but doesn't end up in toplevel, thereby allowing references to toplevel";

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -524,9 +524,11 @@ in
         UUID for this MicroVM, used for:
         - Registration with systemd-machined
         - SMBIOS system UUID (QEMU only)
-        - Guest /etc/machine-id initialization
+        - Guest /etc/machine-id initialization when explicitly set
 
-        If null, a deterministic UUIDv5 is generated from the hostname.
+        If null, a deterministic UUIDv5 is generated at runtime from the hostname
+        for machined registration and SMBIOS UUID.
+
         Format: 8-4-4-4-12 hex digits (standard UUID format).
       '';
     };

--- a/nixos-modules/microvm/system.nix
+++ b/nixos-modules/microvm/system.nix
@@ -58,5 +58,10 @@
         generators = { systemd-gpt-auto-generator = "/dev/null"; };
       };
 
+    # Set /etc/machine-id from machineId if provided
+    # This ensures the guest machine-id matches the UUID passed to machined and SMBIOS
+    environment.etc."machine-id" = lib.mkIf (config.microvm.machineId != null) {
+      text = lib.replaceString "-" "" config.microvm.machineId + "\n";
+    };
   };
 }

--- a/nixos-modules/microvm/system.nix
+++ b/nixos-modules/microvm/system.nix
@@ -63,5 +63,9 @@
     environment.etc."machine-id" = lib.mkIf (config.microvm.machineId != null) {
       text = lib.replaceString "-" "" config.microvm.machineId + "\n";
     };
+    # Generate hostId from machine-id like systemd would do
+    networking.hostId = lib.mkDefault (
+      builtins.substring 0 8 config.microvm.machineId
+    );
   };
 }

--- a/nixos-modules/microvm/vsock-ssh.nix
+++ b/nixos-modules/microvm/vsock-ssh.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.microvm.vsock;
+in
+{
+  options.microvm.vsock.ssh = {
+    enable = lib.mkEnableOption ''
+      SSH server listening on VSOCK for host-to-guest connections.
+
+      When enabled, the guest's SSH server will listen on the VSOCK interface, allowing the host to connect without
+      network configuration. Requires `microvm.vsock.cid` to be set.
+
+      From the host, connect using:
+      - For qemu/crosvm/kvmtool: `ssh vsock/<CID>`
+      - For cloud-hypervisor: `ssh vsock-mux/<path-to-notify.vsock>`
+      - Or use: `microvm -s <vmname>`
+    '';
+  };
+
+  config = lib.mkIf cfg.ssh.enable {
+    assertions = [{
+      assertion = cfg.cid != null;
+      message = "microvm.vsock.ssh.enable requires microvm.vsock.cid to be set";
+    }];
+
+    services.openssh.enable = true;
+
+    # systemd's ssh-generator automatically creates sshd-vsock.socket when it detects VSOCK is available,
+    # so we don't need to configure the socket manually. It will listen on vsock::22.
+  };
+}

--- a/pkgs/microvm-command.nix
+++ b/pkgs/microvm-command.nix
@@ -1,6 +1,11 @@
-{ pkgs }:
-
-with pkgs;
+{ lib
+, git
+, jq
+, nix
+, openssh
+, writeShellScriptBin
+, stateDir ? "/var/lib/microvms"
+}:
 
 let
   colors = {
@@ -18,9 +23,9 @@ writeShellScriptBin "microvm" ''
   set -e
 
   PATH=${lib.makeBinPath [
-    git jq nix
+    git jq nix openssh
   ]}:$PATH
-  STATE_DIR=/var/lib/microvms
+  STATE_DIR=${stateDir}
   ACTION=help
   FLAKE=git+file:///etc/nixos
   RESTART=n
@@ -40,6 +45,11 @@ writeShellScriptBin "microvm" ''
 
       r)
         ACTION=run
+        NAME=$OPTARG
+        ;;
+
+      s)
+        ACTION=ssh
         NAME=$OPTARG
         ;;
 
@@ -88,6 +98,7 @@ writeShellScriptBin "microvm" ''
           -c <name>   Create a MicroVM
           -u <names>  Rebuild (update) MicroVMs
           -r <name>   Run a MicroVM in foreground
+          -s <name>   SSH into a MicroVM via VSOCK
           -l          List MicroVMs
 
   Flags:
@@ -194,6 +205,55 @@ writeShellScriptBin "microvm" ''
           fi
         fi
       done
+      ;;
+
+    ssh)
+      if [ ! -d "$DIR" ]; then
+        echo -e "${colored "red" "MicroVM $NAME not found"}"
+        exit 1
+      fi
+
+      # Check if VM is running
+      if ! systemctl is-active -q "microvm@$NAME" ; then
+        echo -e "${colored "red" "MicroVM $NAME is not running"}"
+        exit 1
+      fi
+
+      # Get hypervisor type and VSOCK info
+      HYPERVISOR=""
+      if [ -f "$DIR/current/share/microvm/hypervisor" ]; then
+        HYPERVISOR=$(cat "$DIR/current/share/microvm/hypervisor")
+      fi
+
+      VSOCK_CID=""
+      if [ -f "$DIR/current/share/microvm/vsock-cid" ]; then
+        VSOCK_CID=$(cat "$DIR/current/share/microvm/vsock-cid")
+      fi
+
+      if [ -z "$VSOCK_CID" ]; then
+        echo -e "${colored "red" "MicroVM $NAME does not have VSOCK enabled"}"
+        echo "Set microvm.vsock.cid in the VM configuration"
+        exit 1
+      fi
+
+      # Determine SSH target based on hypervisor
+      # cloud-hypervisor uses a Unix socket multiplexer
+      # qemu/crosvm/kvmtool use native AF_VSOCK
+      case "$HYPERVISOR" in
+        cloud-hypervisor)
+          # cloud-hypervisor uses notify.vsock in the working directory
+          SSH_TARGET="vsock-mux/$DIR/notify.vsock"
+          ;;
+        *)
+          # qemu, crosvm, kvmtool use native AF_VSOCK with CID
+          SSH_TARGET="vsock/$VSOCK_CID"
+          ;;
+      esac
+
+      echo -e "${colored "boldCyan" "Connecting to $NAME via VSOCK..."}"
+      # VSOCK is a local host-to-guest transport without network exposure,
+      # and VM host keys change on each rebuild - skip known_hosts checks.
+      exec ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -l root "$SSH_TARGET" "$@"
       ;;
   esac
 ''

--- a/pkgs/microvm-command.nix
+++ b/pkgs/microvm-command.nix
@@ -250,10 +250,30 @@ writeShellScriptBin "microvm" ''
           ;;
       esac
 
+      SSH_EXTRA_OPTS=()
+      SSH_REMOTE_CMD=()
+      if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
+        shift
+        SSH_EXTRA_OPTS=("$@")
+      else
+        SSH_REMOTE_CMD=("$@")
+      fi
+
+      HAS_LOGIN_OPT=false
+      for opt in "''${SSH_REMOTE_CMD[@]}"; do
+        case "$opt" in
+          -l|--login)
+            HAS_LOGIN_OPT=true
+            break
+          ;;
+        esac
+      done
+      if [ "$HAS_LOGIN_OPT" = false ]; then
+        SSH_REMOTE_CMD=("-l" "root" "''${SSH_REMOTE_CMD[@]}")
+      fi
+
       echo -e "${colored "boldCyan" "Connecting to $NAME via VSOCK..."}"
-      # VSOCK is a local host-to-guest transport without network exposure,
-      # and VM host keys change on each rebuild - skip known_hosts checks.
-      exec ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -l root "$SSH_TARGET" "$@"
+      exec ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "''${SSH_EXTRA_OPTS[@]}" "$SSH_TARGET" "''${SSH_REMOTE_CMD[@]}"
       ;;
   esac
 ''


### PR DESCRIPTION
Adds systemd-machined integration and SSH over VSOCK support for MicroVMs.

## machined integration

`microvm.registerWithMachined = true` registers VMs with machined:

```
$ machinectl list
MACHINE    CLASS SERVICE     OS VERSION ADDRESSES
authelia   vm    microvm.nix -  -       -
blackpearl vm    microvm.nix -  -       -
```

- `machinectl list/status/show` for visibility
- `machinectl terminate/kill` to stop VMs

This PR prefers `RegisterMachineEx` on systemd 259+ and falls back to legacy machined calls on older hosts.  
When available, it registers `VSockCID` / `SSHAddress` metadata (plus network interfaces).

`machinectl reboot/poweroff/terminate/kill` all stop the VM without auto-restart (systemd treats signals from machined as intentional stops). Use `systemctl restart microvm@<name>` for restarts.

## SSH over VSOCK

`microvm.vsock.ssh.enable = true` configures guest sshd to listen on VSOCK (requires `microvm.vsock.cid`):

```
$ microvm -s myvm
Connecting to myvm via VSOCK...
[myvm]$
```

Works with qemu/crosvm/kvmtool (native AF_VSOCK) and cloud-hypervisor (socket mux).

This PR also updates `microvm -s` argument handling so SSH options can be forwarded via `--`, e.g.:

- `microvm -s myvm -- -l root -i /path/to/key`

## Other changes

- `microvm -l` respects configured `microvm.stateDir`
- `microvm.machineId` option for consistent UUID handling across machined/SMBIOS/guest machine-id use
- QEMU shutdown script handles missing control socket (fixes restart after external kill)
- imperative `microvm@%i` template tolerates missing `microvm-register` / `microvm-unregister` scripts

## Tests

- expands machined test coverage for VM metadata (`VSockCID`, `SSHAddress`) where applicable
- adds a focused `microvm -s` argument-handling test
- adds imperative template test for start/stop without register scripts

Closes #123