### PR TITLE
fix: add Before= ordering for macvtap-interfaces in install-microvm

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -69,6 +69,7 @@ in
         before = [
           "microvm@${name}.service"
           "microvm-tap-interfaces@${name}.service"
+          "microvm-macvtap-interfaces@${name}.service"
           "microvm-pci-devices@${name}.service"
           "microvm-virtiofsd@${name}.service"
         ];


### PR DESCRIPTION
There's a race condition during boot where `microvm-macvtap-interfaces@<name>.service` can be skipped because `install-microvm-<name>.service` hasn't created the required symlinks yet.

On first boot or after configuration changes, the microvm fails to start with errors like:
```
/var/lib/microvms/<name>/current/bin/microvm-run: line 6: /sys/class/net/vm-xxxxxxxxxxxx/ifindex: No such file or directory
/var/lib/microvms/<name>/current/bin/microvm-run: line 6: /dev/tap: Permission denied
microvm@<name>.service: Main process exited, code=exited, status=1/FAILURE
```

The journal shows:
```
Setup MicroVM '<name>' MACVTAP interfaces was skipped because of an unmet condition check (ConditionPathExists=/var/lib/microvms/<name>/current/bin/macvtap-up)
```

The microvm succeeds on the automatic restart (after `install-microvm` has completed).

The `microvm-macvtap-interfaces@<name>.service` has a `ConditionPathExists=/var/lib/microvms/<name>/current/bin/macvtap-up` but no ordering constraint to ensure `install-microvm-<name>.service` runs first.