### PR TITLE
Fix unmounting /nix/store on shutdown

### DIFF
--- a/nixos-modules/microvm/mounts.nix
+++ b/nixos-modules/microvm/mounts.nix
@@ -129,4 +129,12 @@ lib.mkIf config.microvm.guest.enable {
       };
     }) {} config.microvm.shares
   ) ];
+
+  # Fix unmounting in qemu on shutdown for /nix/store
+  systemd.mounts = lib.mkIf (config.boot.initrd.systemd.enable && !storeOnDisk && writableStoreOverlay == null) [ {
+    what = "store";
+    where = "/nix/store";
+    overrideStrategy = "asDropin";
+    unitConfig.DefaultDependencies = false;
+  } ];
 }


### PR DESCRIPTION
Closes #464

Cloud-hypervisor before and with this shows `[FAILED] Failed unmounting /nix/store` but qemu does not log an error anymore and now cleanly exits.