### PR TITLE
Keep booted symlink for teardown

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -77,6 +77,7 @@ in
           "microvm-macvtap-interfaces@${name}.service"
           "microvm-pci-devices@${name}.service"
           "microvm-virtiofsd@${name}.service"
+          "microvm-set-booted@${name}.service"
         ];
         partOf = [ "microvm@${name}.service" ];
         wantedBy = [ "microvms.target" ];
@@ -140,7 +141,7 @@ in
         description = "Setup MicroVM '%i' TAP interfaces";
         before = [ "microvm@%i.service" ];
         partOf = [ "microvm@%i.service" ];
-        after = [ "network.target" ];
+        after = [ "network.target" "microvm-set-booted@%i.service" ];
         unitConfig.ConditionPathExists = "${stateDir}/%i/current/bin/tap-up";
         restartIfChanged = false;
         serviceConfig = {
@@ -155,6 +156,7 @@ in
       "microvm-macvtap-interfaces@" = {
         description = "Setup MicroVM '%i' MACVTAP interfaces";
         before = [ "microvm@%i.service" ];
+        after = [ "microvm-set-booted@%i.service" ];
         partOf = [ "microvm@%i.service" ];
         unitConfig.ConditionPathExists = "${stateDir}/%i/current/bin/macvtap-up";
         restartIfChanged = false;
@@ -199,7 +201,7 @@ in
         in {
           description = "VirtioFS daemons for MicroVM '%i'";
           before = [ "microvm@%i.service" ];
-          after = [ "local-fs.target" ];
+          after = [ "local-fs.target" "microvm-set-booted@%i.service" ];
           partOf = [ "microvm@%i.service" ];
           unitConfig.ConditionPathExists = "${stateDir}/%i/current/bin/virtiofsd-run";
           restartIfChanged = false;
@@ -217,6 +219,26 @@ in
           };
         };
 
+      "microvm-set-booted@" = {
+        description = "Save MicroVM '%i' booted configuration";
+        before = [ "microvm@%i.service" ];
+        partOf = [ "microvm@%i.service" ];
+        restartIfChanged = false;
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          SyslogIdentifier = "microvm-set-booted@%i";
+          WorkingDirectory = "${stateDir}/%i";
+          User = user;
+          Group = group;
+          ExecStop = "${lib.getExe' pkgs.coreutils "rm"} booted";
+        };
+        script = ''
+          rm -f booted
+          ln -s $(readlink current) booted
+        '';
+      };
+
       "microvm@" = {
         description = "MicroVM '%i'";
         requires = [
@@ -224,6 +246,7 @@ in
           "microvm-macvtap-interfaces@%i.service"
           "microvm-pci-devices@%i.service"
           "microvm-virtiofsd@%i.service"
+          "microvm-set-booted@%i.service"
         ];
         after = [
           "network.target"
@@ -231,16 +254,10 @@ in
           "microvm-macvtap-interfaces@%i.service"
           "microvm-pci-devices@%i.service"
           "microvm-virtiofsd@%i.service"
+          "microvm-set-booted@%i.service"
         ];
         unitConfig.ConditionPathExists = "${stateDir}/%i/current/bin/microvm-run";
         restartIfChanged = false;
-        preStart = ''
-          rm -f booted
-          ln -s $(readlink current) booted
-        '';
-        postStop = ''
-          rm booted
-        '';
         serviceConfig = {
           Type =
             if config.microvm.host.useNotifySockets


### PR DESCRIPTION
Create and remote the symlink in a separate systems service,
so that it is available during all setup and teardown tasks.
This is important for e.g. properly removing TAP interfaces,
which seems to not work since https://github.com/microvm-nix/microvm.nix/commit/d25949acb624f2d7d7f3dd09ab9a38e9016eefba.

~~The virtiofs service seems to have a workaround for `booted` not existing any more, remove it.~~