### PR TITLE
shut down supervisord with SIGTERM instead of using supervisorctl

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -182,21 +182,7 @@ in
         };
       };
 
-      "microvm-virtiofsd@" =
-        let
-          runFromBootedOrCurrent = pkgs.writeShellScript "microvm-runFromBootedOrCurrent" ''
-            NAME="$1"
-            VM="$2"
-            cd "${stateDir}/$VM"
-
-            if [ -e booted ]; then
-              exec booted/bin/$NAME
-            else
-              exec current/bin/$NAME
-            fi
-          '';
-
-        in {
+      "microvm-virtiofsd@" = {
           description = "VirtioFS daemons for MicroVM '%i'";
           before = [ "microvm@%i.service" ];
           after = [ "local-fs.target" ];
@@ -206,7 +192,6 @@ in
           serviceConfig = {
             WorkingDirectory = "${stateDir}/%i";
             ExecStart = "${stateDir}/%i/current/bin/virtiofsd-run";
-            ExecStop = "${runFromBootedOrCurrent} virtiofsd-shutdown %i";
             LimitNOFILE = 1048576;
             NotifyAccess = "all";
             PrivateTmp = "yes";
@@ -214,6 +199,7 @@ in
             RestartSec = "5s";
             SyslogIdentifier = "microvm-virtiofsd@%i";
             Type = "notify";
+            KillMode = "mixed";
           };
         };
 

--- a/nixos-modules/microvm/virtiofsd/default.nix
+++ b/nixos-modules/microvm/virtiofsd/default.nix
@@ -33,7 +33,6 @@ in
             value = {
               stderr_syslog = true;
               stdout_syslog = true;
-              autorestart = true;
               command = pkgs.writeShellScript "virtiofsd-${tag}" ''
                 if [ $(id -u) = 0 ]; then
                   OPT_RLIMIT="--rlimit-nofile 1048576"
@@ -70,9 +69,5 @@ in
       in ''
         exec ${supervisord} --configuration ${supervisordConfigFile}
       '';
-
-    virtiofsd-shutdown = ''
-      exec ${supervisorctl} stop
-    '';
   };
 }


### PR DESCRIPTION
supervisord interprets SIGTERM as exit request and will shut down the services. Setting KillMode=mixed ensures that systemd does not kill the virtiofsd+notify processes (supervisord will do that).

This commit also drops the autorestart=true from the virtiofsd instances. Since virtiofsd exits on its own with exit code 0 when the VM exits, we do not want supervisord to restart it only to kill it again when the VM has shut down and systemd shuts this service down. Since the default autorestart is "unexpected", supervisord should still restart virtiofsd after abnormal (non-0) exits.
Next to being useless, I've observed (unfortunately without being able to reliably reporduce) that the restart-and-immediately-kill often leads to the virtiofsd process seemingly ignoring the SIGTERM (probably it if is sent before the execve(2), where the supervisord signal handler is still in place). Hence, supervisord waits for virtiofsd to exit for multiple seconds before timing out and killing it, slowing down the shutdown duration.

Why this change? supervisorctl fails with "connection refused", so that shutting down this service means waiting for systemd to time out. AFAICT from the docs, supervisorctl needs supervisord to be listening on a unix or HTTP socket, which only happens if explicitly configured, which is not the case.