### PR TITLE
fix: Remove virtiofsd dependency from vfkit

### DIFF
--- a/nixos-modules/microvm/virtiofsd/default.nix
+++ b/nixos-modules/microvm/virtiofsd/default.nix
@@ -5,7 +5,7 @@ let
     proto == "virtiofs"
   ) config.microvm.shares;
 
-  requiresVirtiofsd = virtiofsShares != [];
+  requiresVirtiofsd = virtiofsShares != [] && config.microvm.hypervisor != "vfkit";
 
   inherit (pkgs.python3Packages) supervisor;
   supervisord = lib.getExe' supervisor "supervisord";


### PR DESCRIPTION
vfkit does not require an additional virtiofs daemon. vfkit uses Apple Virtualization.framework directly to create the virtio share.

viritiofsd is unused in this configuration, but is still a dependency. Rust virtiofsd is not supported on MacOS yet and will not build. See https://gitlab.com/virtio-fs/virtiofsd/-/issues/169

Fixes #467