### PR TITLE
Fixed modules not loaded in stage2 #478

### DIFF
--- a/nixos-modules/microvm/mounts.nix
+++ b/nixos-modules/microvm/mounts.nix
@@ -44,7 +44,7 @@ lib.mkIf config.microvm.guest.enable {
       "/nix/store" = {
         device = roStoreDisk;
         fsType = storeDiskType;
-        options = [ "x-systemd.requires=systemd-modules-load.service" ];
+        options = [ "x-systemd.after=systemd-modules-load.service" ];
         neededForBoot = true;
         noCheck = true;
       };
@@ -72,7 +72,7 @@ lib.mkIf config.microvm.guest.enable {
       "/nix/.ro-store" = {
         device = roStoreDisk;
         fsType = storeDiskType;
-        options = [ "ro" "x-systemd.requires=systemd-modules-load.service" ];
+        options = [ "ro" "x-systemd.after=systemd-modules-load.service" ];
         neededForBoot = true;
         noCheck = true;
       };
@@ -121,8 +121,8 @@ lib.mkIf config.microvm.guest.enable {
         device = tag;
         fsType = proto;
         options = {
-          "virtiofs" = [ "defaults" "x-systemd.requires=systemd-modules-load.service" ];
-          "9p" = [ "trans=virtio" "version=9p2000.L" "msize=65536" "x-systemd.requires=systemd-modules-load.service" ];
+          "virtiofs" = [ "defaults" "x-systemd.after=systemd-modules-load.service" ];
+          "9p" = [ "trans=virtio" "version=9p2000.L" "msize=65536" "x-systemd.after=systemd-modules-load.service" ];
         }.${proto};
       } // lib.optionalAttrs (source == "/nix/store" || mountPoint == config.microvm.writableStoreOverlay) {
         neededForBoot = true;


### PR DESCRIPTION
Fixed systemd hard dependency that kept `systemd-modules-load` active at handover to stage2.

This fix properly stops the the `systemd-modules-load` and allows stage2 modules also be loaded

see more #478 

With this PR there is proper handover to stage2

```

[root@europa:~]# journalctl -u systemd-modules-load --no-pager
Feb 26 07:32:57 europa systemd-modules-load[86]: Inserted module '9p'
Feb 26 07:32:57 europa systemd-modules-load[86]: Inserted module '9pnet_virtio'
Feb 26 07:32:57 europa systemd-modules-load[86]: Inserted module 'dm_mod'
Feb 26 07:32:57 europa systemd-modules-load[86]: Inserted module 'nvme'
Feb 26 07:32:57 europa systemd-modules-load[86]: Inserted module 'virtio_blk'
Feb 26 07:32:57 europa systemd-modules-load[86]: Inserted module 'virtio_mmio'
Feb 26 07:32:57 europa systemd-modules-load[86]: Inserted module 'virtiofs'
Feb 26 07:32:57 europa systemd[1]: Finished Load Kernel Modules.
Feb 26 07:32:59 europa systemd[1]: systemd-modules-load.service: Deactivated successfully.
Feb 26 07:32:59 europa systemd[1]: Stopped Load Kernel Modules.
Feb 26 07:33:02 europa systemd-modules-load[414]: Inserted module 'br_netfilter'
Feb 26 07:33:02 europa systemd-modules-load[414]: Inserted module 'ib_core'
Feb 26 07:33:02 europa systemd-modules-load[414]: Inserted module 'ib_uverbs'
Feb 26 07:33:02 europa systemd-modules-load[414]: Inserted module 'loop'
Feb 26 07:33:02 europa systemd-modules-load[414]: Inserted module 'mlx5_core'
Feb 26 07:33:02 europa systemd-modules-load[414]: Inserted module 'mlx5_ib'
Feb 26 07:33:02 europa systemd-modules-load[414]: Inserted module 'overlay'
Feb 26 07:33:02 europa systemd-modules-load[414]: Inserted module 'rdma_cm'
Feb 26 07:33:02 europa systemd-modules-load[414]: Inserted module 'tap'
Feb 26 07:33:02 europa systemd-modules-load[414]: Inserted module 'vhost_net'
Feb 26 07:33:02 europa systemd[1]: Finished Load Kernel Modules.


```