### PR TITLE
feat: add virtiofs share cache policy option

### DIFF
--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -410,6 +410,11 @@ in
             description = "Turn off write access";
             default = false;
           };
+          cache = mkOption {
+            type = enum [ "auto" "always" "metadata" "never" ];
+            description = "Virtiofs caching policy for the file system, ignored when 9p is used";
+            default = "auto";
+          };
         };
       }));
     };

--- a/nixos-modules/microvm/virtiofsd/default.nix
+++ b/nixos-modules/microvm/virtiofsd/default.nix
@@ -28,7 +28,7 @@ in
             events = "PROCESS_STATE";
           };
         } // builtins.listToAttrs (
-          map ({ tag, socket, source, readOnly, ... }: {
+          map ({ tag, socket, source, readOnly, cache, ... }: {
             name = "program:virtiofsd-${tag}";
             value = {
               stderr_syslog = true;
@@ -48,6 +48,7 @@ in
                   $OPT_RLIMIT \
                   --thread-pool-size ${toString config.microvm.virtiofsd.threadPoolSize} \
                   --posix-acl --xattr \
+                  --cache=${cache} \
                   ${lib.optionalString (config.microvm.virtiofsd.inodeFileHandles != null)
                     "--inode-file-handles=${config.microvm.virtiofsd.inodeFileHandles}"
                   } \


### PR DESCRIPTION
Added a per-share virtiofs `cache` policy option, which allows configuring the caching policy that the file system should report to the FUSE client.


**Cache policy settings:**
- **`never`** - The client should never cache file data and all I/O should be directly forwarded to the server.
   This policy must be selected when file contents may change without the knowledge of the FUSE client (i.e., the file system does not have exclusive access to the directory)
- **`metadata`** - This is almost same as Never, but it allows page cache of directories, dentries and attr cache in guest.
   In other words, it acts like `cache=never` for normal files, and like `cache=always` for directories, besides, metadata like dentries and attrs are kept as well.
   This policy can be used if:
   1. the client wants to use Never policy but it's performance in I/O is not good enough
   2. the file system has exclusive access to the directory
   3. cache directory content and other fs metadata can make a difference on performance.
- **`auto`** - Default.
   The client is free to choose when and how to cache file data.
   By default the FUSE protocol uses close-to-open consistency. This means that any cached contents of the file are invalidated the next time that file is opened.
- **`always`** - The client should always cache file data.
   This means that the FUSE client will not invalidate any cached data that was returned by the file system the last time the file was opened.
   This policy should only be selected when the file system has exclusive access to the directory.

Virtiofs cache policy descriptions taken from here:
https://gitlab.com/virtio-fs/virtiofsd/-/blob/main/src/passthrough/mod.rs#L95

The default value remains `auto`.

---
### Example configuration enabling forced cache for a typical `/nix/store` share:
```nix
microvm.shares = [ {
  tag = "ro-store";
  source = "/nix/store";
  mountPoint = "/nix/.ro-store";
  proto = "virtiofs";
  cache = "always";
} ];
```