### PR TITLE
Fix 2-second systemd notify stalls in cloud-hypervisor

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -138,27 +138,28 @@ let
   # An important caveat is that the message could theoretically be truncated but this should not
   # happen in practice unless the message is large (systemd notifications are small).
   #
-  # TODO(rzhikharevich): Ideally, cloud-hypervisor should propagate the half-close, then the
+  # TODO: Ideally, cloud-hypervisor should propagate the half-close, then the
   # theoretical truncation risk could be fixed by closing the connection after detecting it.
   vsockNotifyProxy = pkgs.writers.writePython3Bin "vsock-notify-proxy" {} ''
     import asyncio
     import os
     import socket
+    import sys
 
-    notify_socket = os.environ["NOTIFY_SOCKET"]
     notify = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    notify.connect(os.environ["NOTIFY_SOCKET"])
 
 
     async def handle(reader, writer):
         data = await reader.read(65536)
         writer.close()
         if data:
-            notify.sendto(data, notify_socket)
+            notify.send(data)
+        await writer.wait_closed()
 
 
     async def main():
-        path = os.environ["VSOCK_NOTIFY_PATH"]
-        server = await asyncio.start_unix_server(handle, path=path)
+        server = await asyncio.start_unix_server(handle, path=sys.argv[1])
         await server.serve_forever()
 
 
@@ -196,7 +197,7 @@ in {
 
     # Forward systemd notify messages from guest (via vsock) to host
     if [ -n "''${NOTIFY_SOCKET:-}" ]; then
-      VSOCK_NOTIFY_PATH=${vsockPath}_8888 ${vsockNotifyProxy}/bin/vsock-notify-proxy &
+      ${vsockNotifyProxy}/bin/vsock-notify-proxy ${vsockPath}_8888 &
     fi
   '' + lib.optionalString graphics.enable ''
     rm -f ${graphics.socket}

--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -126,6 +126,45 @@ let
     vulkan = true;
   };
 
+  # A lightweight proxy that forwards systemd notifications from a vsock
+  # Unix socket to the host's NOTIFY_SOCKET. Unlike socat, it closes the
+  # connection immediately after reading, which unblocks the guest's
+  # blocking recv() (systemd does shutdown(SHUT_WR) + recv() as an
+  # end-of-message handshake, but cloud-hypervisor does not propagate the
+  # half-close to the host-side Unix socket).
+  vsockNotifyProxy = pkgs.writers.writePython3Bin "vsock-notify-proxy" {} ''
+    import asyncio
+    import os
+    import socket
+
+    notify_socket = os.environ["NOTIFY_SOCKET"]
+    notify = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+
+
+    async def handle(reader, writer):
+        chunks = []
+        while True:
+            chunk = await reader.read(65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            if chunk.endswith(b"\n"):
+                break
+        writer.close()
+        data = b"".join(chunks)
+        if data:
+            notify.sendto(data, notify_socket)
+
+
+    async def main():
+        path = os.environ["VSOCK_NOTIFY_PATH"]
+        server = await asyncio.start_unix_server(handle, path=path)
+        await server.serve_forever()
+
+
+    asyncio.run(main())
+  '';
+
   oemStringValues = platformOEMStrings ++ lib.optional supportsNotifySocket "io.systemd.credential:vmm.notify_socket=vsock-stream:2:8888";
   oemStringOptions = lib.optional (oemStringValues != []) "oem_strings=[${lib.concatStringsSep "," oemStringValues}]";
   platformExtracted = extractOptValues "--platform" extraArgs;
@@ -155,11 +194,9 @@ in {
     # Ensure notify sockets are removed if cloud-hypervisor didn't exit cleanly the last time
     rm -f ${vsockPath} ${vsockPath}_8888
 
-    # Start socat to forward systemd notify socket over vsock
+    # Forward systemd notify messages from guest (via vsock) to host
     if [ -n "''${NOTIFY_SOCKET:-}" ]; then
-      # -T2 is required because cloud-hypervisor does not handle partial
-      # shutdown of the stream, like systemd v256+ does.
-      ${pkgs.socat}/bin/socat -T2 UNIX-LISTEN:${vsockPath}_8888,fork UNIX-SENDTO:$NOTIFY_SOCKET &
+      VSOCK_NOTIFY_PATH=${vsockPath}_8888 ${vsockNotifyProxy}/bin/vsock-notify-proxy &
     fi
   '' + lib.optionalString graphics.enable ''
     rm -f ${graphics.socket}

--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -142,16 +142,8 @@ let
 
 
     async def handle(reader, writer):
-        chunks = []
-        while True:
-            chunk = await reader.read(65536)
-            if not chunk:
-                break
-            chunks.append(chunk)
-            if chunk.endswith(b"\n"):
-                break
+        data = await reader.read(65536)
         writer.close()
-        data = b"".join(chunks)
         if data:
             notify.sendto(data, notify_socket)
 

--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -126,12 +126,20 @@ let
     vulkan = true;
   };
 
-  # A lightweight proxy that forwards systemd notifications from a vsock
-  # Unix socket to the host's NOTIFY_SOCKET. Unlike socat, it closes the
-  # connection immediately after reading, which unblocks the guest's
-  # blocking recv() (systemd does shutdown(SHUT_WR) + recv() as an
-  # end-of-message handshake, but cloud-hypervisor does not propagate the
-  # half-close to the host-side Unix socket).
+  # A proxy that forwards systemd notifications from cloud-hypervisor's vsock socket. It
+  # intentionally calls read only once and closes the connection immediately, which unblocks the
+  # guest's blocking recv() (systemd does shutdown(SHUT_WR) + recv() as an
+  # end-of-message handshake in sd-daemon.c, but cloud-hypervisor does not propagate the half-close
+  # to the host-side Unix socket).
+  #
+  # Previously, this used socat with a 2-second timeout but this causes systemd to stall on every
+  # notification, causing extremely slow boot times.
+  #
+  # An important caveat is that the message could theoretically be truncated but this should not
+  # happen in practice unless the message is large (systemd notifications are small).
+  #
+  # TODO(rzhikharevich): Ideally, cloud-hypervisor should propagate the half-close, then the
+  # theoretical truncation risk could be fixed by closing the connection after detecting it.
   vsockNotifyProxy = pkgs.writers.writePython3Bin "vsock-notify-proxy" {} ''
     import asyncio
     import os


### PR DESCRIPTION
This is a fix for #474. See the code comment for explanation and caveats.

Relevant parts of:
- systemd: [sd-daemon.c:630](https://github.com/systemd/systemd/blob/5f2258affcbcf7690da9655308a1f308d0baf7fd/src/libsystemd/sd-daemon/sd-daemon.c#L630)
- [cloud-hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/c06f6c32932e3241676ba658a8fa9b2852d9e305/virtio-devices/src/vsock/csm/connection.rs#L339)