### PR TITLE
fix(firecracker): remove noapic acpi=off from Firecracker boot_args for PCI mode

### DIFF
--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -24,7 +24,7 @@ let
     boot-source = {
       kernel_image_path = kernelPath;
       initrd_path = initrdPath;
-      boot_args = "console=ttyS0,115200 noapic acpi=off reboot=k panic=1 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd ${toString microvmConfig.kernelParams}";
+      boot_args = "console=ttyS0,115200 reboot=k panic=1 i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd ${toString microvmConfig.kernelParams}";
     };
     machine-config = {
       vcpu_count = vcpu;


### PR DESCRIPTION
PR #428 added `--enable-pci` for Firecracker >= 1.13.0, but the hardcoded `boot_args` still contain `noapic acpi=off`. With `acpi=off`, the guest kernel cannot parse the ACPI MCFG table Firecracker provides to discover the ECAM region, so PCI device enumeration fails and the VM hangs at boot.

`noapic` disables the IO-APIC, which is unnecessary with PCI transport since virtio PCI devices use MSI-X (bypasses IO-APIC entirely).

Removing both params resolves the boot hang and allows `--enable-pci` to work as intended.

Tested on a 14-VM Firecracker fleet (NixOS, kernel 6.12, Firecracker 1.13.2): all VMs boot and run correctly with PCI transport after this change.

Fixes #496