### PR TITLE
docs: explain Linux builder requirement on macOS

### DIFF
--- a/doc/src/faq.md
+++ b/doc/src/faq.md
@@ -139,8 +139,8 @@ individually used block devices.
 On macOS, **microvm.nix** uses the `vfkit` hypervisor to run Linux
 guests through Apple's native Virtualization.framework. While vfkit
 itself runs natively on macOS, the guest NixOS system still has to be
-built for Linux, and `aarch64-darwin` / `x86_64-darwin` cannot produce
-Linux store paths on their own. You therefore need access to a Linux
+built for Linux, and `aarch64-darwin` / `x86_64-darwin` cannot compile
+or cross compile those. You therefore need access to a Linux
 builder. Without one, `nix run` will fail with errors like:
 
 ```

--- a/doc/src/faq.md
+++ b/doc/src/faq.md
@@ -134,6 +134,42 @@ The more secure solution would be writing custom
 `services.udev.extraRules` that assign ownership/permissions to the
 individually used block devices.
 
+## I'm on macOS and builds fail with `Required system: 'aarch64-linux'`. What do I do?
+
+On macOS, **microvm.nix** uses the `vfkit` hypervisor to run Linux
+guests through Apple's native Virtualization.framework. While vfkit
+itself runs natively on macOS, the guest NixOS system still has to be
+built for Linux, and `aarch64-darwin` / `x86_64-darwin` cannot produce
+Linux store paths on their own. You therefore need access to a Linux
+builder. Without one, `nix run` will fail with errors like:
+
+```
+error: Cannot build '/nix/store/...-nixos-system-....drv'.
+       Reason: required system or feature not available
+       Required system: 'aarch64-linux' with features {}
+       Current system: 'aarch64-darwin' with features {apple-virt, ...}
+```
+
+Any of the following approaches work — pick whichever fits your setup:
+
+- **nix-darwin `linux-builder`**: nixpkgs ships a lightweight Linux
+  builder VM that integrates with nix-darwin. Enable it with
+  `nix.linux-builder.enable = true;` in your `darwin-configuration.nix`.
+  See the [nixcademy write-up](https://nixcademy.com/posts/macos-linux-builder/)
+  for a walkthrough.
+- **Determinate Nix native Linux builder**: [Determinate Nix](https://docs.determinate.systems/troubleshooting/native-linux-builder/)
+  provides a native Linux builder on macOS (currently in closed beta).
+- **`nix-rosetta-builder`**: [`nix-rosetta-builder`](https://github.com/cpick/nix-rosetta-builder)
+  runs an `x86_64-linux` builder on Apple Silicon through Rosetta —
+  useful when you specifically need an `x86_64-linux` builder.
+- **Remote Linux machine**: configure an existing Linux machine as a
+  remote builder via `/etc/nix/machines`.
+
+The `microvm.cachix.org` substituter advertised by the flake is
+**optional**. If you prefer not to trust additional binary caches,
+decline the prompt (or pass `--no-accept-flake-config`) and Nix will
+build everything from source on your Linux builder.
+
 ## My virtiofs-shared sops-nix /run/secrets disappears when the host is updated!
 
 A workaround may be setting `sops.keepGenerations = 0;`, effectively

--- a/doc/src/intro.md
+++ b/doc/src/intro.md
@@ -48,7 +48,7 @@ This Flake offers you to run your MicroVMs not only on QEMU but with
 other Hypervisors that have been explicitly authored for
 *virtio*. Some of them are written in Rust, a programming language
 that is renowned for being safer than C. On macOS, vfkit leverages
-Apple's native Virtualization.framework for running Linux VMs. Note
-that building the guest still requires access to a Linux builder; see
+Apple's native Virtualization.framework for running Linux VMs.
+Note that building the guest still requires access to a Linux builder; see
 [the FAQ](./faq.md#im-on-macos-and-builds-fail-with-required-system-aarch64-linux-what-do-i-do)
 for setup options.

--- a/doc/src/intro.md
+++ b/doc/src/intro.md
@@ -48,4 +48,7 @@ This Flake offers you to run your MicroVMs not only on QEMU but with
 other Hypervisors that have been explicitly authored for
 *virtio*. Some of them are written in Rust, a programming language
 that is renowned for being safer than C. On macOS, vfkit leverages
-Apple's native Virtualization.framework for running Linux VMs.
+Apple's native Virtualization.framework for running Linux VMs. Note
+that building the guest still requires access to a Linux builder; see
+[the FAQ](./faq.md#im-on-macos-and-builds-fail-with-required-system-aarch64-linux-what-do-i-do)
+for setup options.


### PR DESCRIPTION
## Summary
- Adds an FAQ entry covering the `Required system: 'aarch64-linux'` error that macOS users hit when running vfkit MicroVMs without a Linux builder, with the available builder options (nix-darwin `linux-builder`, Determinate Nix native builder, `nix-rosetta-builder`, remote machine).
- Adds a one-line pointer to the FAQ from the existing macOS/vfkit mention in the intro, so readers see the requirement before hitting the error.
- Notes that the `microvm.cachix.org` substituter is optional, addressing the concern raised in the issue about not wanting to trust extra caches.

Closes #491

## Test plan
- [x] `mdbook build doc` succeeds
- [x] Verified the intro link resolves to the generated FAQ anchor (`faq.html#im-on-macos-and-builds-fail-with-required-system-aarch64-linux-what-do-i-do`)