### PR TITLE
explicitly set fsType for bind mounted nix store

### DIFF
--- a/nixos-modules/microvm/mounts.nix
+++ b/nixos-modules/microvm/mounts.nix
@@ -59,6 +59,7 @@ lib.mkIf config.microvm.guest.enable {
     ) {
       "/nix/store" = {
         device = hostStore.mountPoint;
+        fsType = hostStore.proto;
         options = [ "ro" "bind" ];
         neededForBoot = true;
       };


### PR DESCRIPTION
In nixos-unstable / nixos-26.05, fsType is no longer set to `auto` by default, so the appropriate type must be explicitly specified. Fixes #500