### PR TITLE
Explicitly set user in supervisord config

### DIFF
--- a/nixos-modules/microvm/virtiofsd/default.nix
+++ b/nixos-modules/microvm/virtiofsd/default.nix
@@ -16,7 +16,10 @@ in
     virtiofsd-run =
       let
         supervisordConfig = {
-          supervisord.nodaemon = true;
+          supervisord = {
+            nodaemon = true;
+            user = "root";
+          };
 
           "eventlistener:notify" = {
             command = pkgs.writers.writePython3 "supervisord-event-handler" { } (


### PR DESCRIPTION
The `microvm-virtiofsd@` service runs as root by design,
because virtiofsd needs root privileges to set `--rlimit-nofile 1048576`.
However, the supervisord configuration did not explicitly declare `user = "root"`,
causing supervisord to emit a CRIT-level warning on every start:

CRIT Supervisor is running as root.
Privileges were not dropped because no user is specified in the config file.
If you intend to run as root,
you can set user=root in the config file to avoid this message.

This commit adds `user = "root"` to the `[supervisord]` section of the generated config to suppress this warning,
making it explicit that running as root is intentional.
