### PR TITLE
fix: use host-architecture packages for build-time derivations

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -14,9 +14,9 @@ let
     configureFlags = oa.configureFlags ++ [
       "--enable-libusb"
     ];
-    buildInputs = oa.buildInputs ++ (with pkgs; [
-      libusb1
-    ]);
+    buildInputs = oa.buildInputs ++ [
+      vmHostPackages.libusb1
+    ];
   });
 
   minimizeQemuClosureSize = pkg: pkg.override (oa: {
@@ -133,7 +133,7 @@ let
     host = "hostfwd=${proto}:${host.address}:${toString host.port}-" +
            "${guest.address}:${toString guest.port},";
     guest = "guestfwd=${proto}:${guest.address}:${toString guest.port}-" +
-            "cmd:${pkgs.netcat}/bin/nc ${host.address} ${toString host.port},";
+            "cmd:${vmHostPackages.netcat}/bin/nc ${host.address} ${toString host.port},";
   }.${from}) forwardPorts;
 
   writeQmp = data: ''

--- a/nixos-modules/microvm/boot-disk.nix
+++ b/nixos-modules/microvm/boot-disk.nix
@@ -21,12 +21,12 @@ in {
   };
 
   config = lib.mkIf config.microvm.guest.enable {
-    microvm.bootDisk = pkgs.runCommandLocal "microvm-bootdisk.img" {
-      nativeBuildInputs = with pkgs; [
+    microvm.bootDisk = pkgs.buildPackages.runCommandLocal "microvm-bootdisk.img" {
+      nativeBuildInputs = with pkgs.buildPackages; [
         parted
         libguestfs
       ];
-      LIBGUESTFS_PATH = pkgs.libguestfs-appliance;
+      LIBGUESTFS_PATH = pkgs.buildPackages.libguestfs-appliance;
     } ''
       # kernel + initrd + slack, in sectors
       EFI_SIZE=$(( ( ( $(stat -c %s ${kernelPath}) + $(stat -c %s ${initrdPath}) + 16 * 4096 ) / ( 2048 * 512 ) + 1 ) * 2048 ))

--- a/nixos-modules/microvm/store-disk.nix
+++ b/nixos-modules/microvm/store-disk.nix
@@ -64,7 +64,7 @@ in
         config.microvm.storeDiskType
       ];
 
-      microvm.storeDisk = pkgs.runCommandLocal "microvm-store-disk.${config.microvm.storeDiskType}" {
+      microvm.storeDisk = pkgs.buildPackages.runCommandLocal "microvm-store-disk.${config.microvm.storeDiskType}" {
         nativeBuildInputs = [
           pkgs.buildPackages.time
           pkgs.buildPackages.bubblewrap


### PR DESCRIPTION
When building a MicroVM for a different architecture
(e.g. aarch64-linux guest on x86_64 host)
with QEMU system emulation,
NixOS module evaluation binds `pkgs` to the guest's package set.
Build-time derivations like `runCommandLocal` and runtime host-side binaries must use host-architecture packages,
otherwise Nix requires binfmt emulation just to build disk images that will run inside the VM anyway.

Changes:
- `boot-disk.nix`: use `pkgs.buildPackages.runCommandLocal` and `pkgs.buildPackages`
  for parted, libguestfs, libguestfs-appliance
- `store-disk.nix`: use `pkgs.buildPackages.runCommandLocal`
  (nativeBuildInputs already used `pkgs.buildPackages`)
- `qemu.nix`: use `vmHostPackages.netcat` for guestfwd command and
  `vmHostPackages.libusb1` for the enableLibusb QEMU override
