### PR TITLE
feat: create share paths on host

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -34,11 +34,45 @@ in
       "vhost_net"
     ];
 
-    systemd.tmpfiles.settings."10-microvm"."${stateDir}".d = {
-      user = user;
-      group = group;
-      mode = "0775";
-    };
+    systemd.tmpfiles.settings."10-microvm" =
+      builtins.foldl'
+        (
+          result: name:
+          result
+          // (
+            let
+              microvmConfig = config.microvm.vms.${name};
+              inherit (microvmConfig) flake;
+              isFlake = flake != null;
+              guestConfig =
+                if isFlake then
+                  flake.nixosConfigurations.${name}.config
+                else if microvmConfig.evaluatedConfig != null then
+                  microvmConfig.evaluatedConfig.config
+                else
+                  microvmConfig.config.config;
+            in
+            builtins.foldl' (
+              result: share:
+              result
+              // lib.optionalAttrs (share.source != "/nix/store") {
+                "${share.source}".d = {
+                  # Only adjust permissions if directory doesn't exist
+                  user = ":${user}";
+                  group = ":${group}";
+                  mode = ":0775";
+                };
+              }
+            ) { } guestConfig.microvm.shares
+          )
+        )
+        {
+          "${stateDir}".d = {
+            inherit user group;
+            mode = "0775";
+          };
+        }
+        (builtins.attrNames config.microvm.vms);
 
     environment.systemPackages = [
       microvmCommand


### PR DESCRIPTION
#316 seems to be more or less abandoned; this implements effectively the same change but using systemd-tmpfiles as suggested in https://github.com/microvm-nix/microvm.nix/pull/316#discussion_r3016587127.