### PR TITLE
host: opt-in stop for orphaned microvm@<name>.service on removal from microvm.vms

### DIFF
--- a/doc/src/declarative.md
+++ b/doc/src/declarative.md
@@ -71,3 +71,31 @@ microvm.vms = {
 
 Note that building MicroVMs with the host increases build time and
 closure size of the host's system.
+
+## Reconciliation on host rebuild
+
+By default, removing a VM from `microvm.vms.<name>` does **not** stop
+the running `microvm@<name>.service`. Out of the box, MicroVM
+lifecycle is decoupled from host configuration — updates are applied
+via the imperative [`microvm` command](./microvm-command.md), and
+removing a declaration simply stops managing the VM declaratively
+without disturbing the running process.
+
+To opt in to reconciliation — so that removing a VM from
+`microvm.vms.<name>` and running `nixos-rebuild switch` stops the
+corresponding `microvm@<name>.service`, matching the behavior of
+ordinary `systemd.services.<name>` — set:
+
+```nix
+microvm.host.stopOrphans = true;
+```
+
+When enabled:
+
+- State under `/var/lib/microvms/<name>/` is preserved, in case the VM
+  is only being temporarily deactivated. To fully remove a VM including
+  its disk images, `rm -rf /var/lib/microvms/<name>` after the service
+  has stopped.
+- Imperative MicroVMs managed via the `microvm` command are never
+  touched; only VMs that were previously declared in `microvm.vms` are
+  considered.

--- a/doc/src/declarative.md
+++ b/doc/src/declarative.md
@@ -74,17 +74,14 @@ closure size of the host's system.
 
 ## Reconciliation on host rebuild
 
-By default, removing a VM from `microvm.vms.<name>` does **not** stop
-the running `microvm@<name>.service`. Out of the box, MicroVM
-lifecycle is decoupled from host configuration — updates are applied
-via the imperative [`microvm` command](./microvm-command.md), and
-removing a declaration simply stops managing the VM declaratively
-without disturbing the running process.
+By default, removing a VM from `microvm.vms.<name>` does **not** stop the running `microvm@<name>.service`,
+because MicroVM lifecycle is decoupled from host configuration.
+Updates are meant to be applied via the imperative [`microvm` command](./microvm-command.md),
+and removing a declaration simply stops managing the VM declaratively.
 
-To opt in to reconciliation — so that removing a VM from
-`microvm.vms.<name>` and running `nixos-rebuild switch` stops the
-corresponding `microvm@<name>.service`, matching the behavior of
-ordinary `systemd.services.<name>` — set:
+To opt in to reconciliation, so that removing a VM from `microvm.vms.<name>`
+and running `nixos-rebuild switch` stops the corresponding `microvm@<name>.service`,
+matches the behavior of ordinary `systemd.services.<name>` set:
 
 ```nix
 microvm.host.stopOrphans = true;
@@ -92,10 +89,7 @@ microvm.host.stopOrphans = true;
 
 When enabled:
 
-- State under `/var/lib/microvms/<name>/` is preserved, in case the VM
-  is only being temporarily deactivated. To fully remove a VM including
-  its disk images, `rm -rf /var/lib/microvms/<name>` after the service
-  has stopped.
-- Imperative MicroVMs managed via the `microvm` command are never
-  touched; only VMs that were previously declared in `microvm.vms` are
-  considered.
+- State under `/var/lib/microvms/<name>/` is preserved, in case the VM is only being temporarily deactivated.
+  To fully remove a VM including its disk images, `rm -rf /var/lib/microvms/<name>` after the service has stopped.
+- Imperative MicroVMs managed via the `microvm` command are never touched;
+  only VMs that were previously declared in `microvm.vms` are considered.

--- a/doc/src/microvm-command.md
+++ b/doc/src/microvm-command.md
@@ -64,16 +64,35 @@ ls -l /var/lib/microvms/*/{current,booted}/share/microvm/system
 
 ## Removing MicroVMs
 
+### Imperative MicroVMs
+
 First, stop the MicroVM:
 
 ```bash
 systemctl stop microvm@$NAME
 ```
 
+### Declarative MicroVMs
+
+Remove the VM from `microvm.vms.<name>` in your host configuration and
+stop the VM:
+
+```bash
+systemctl stop microvm@$NAME
+```
+
+Removing a declaration does **not** automatically stop the running
+service by default. To opt in to that behavior, set
+`microvm.host.stopOrphans = true;` on the host — see
+[Declarative MicroVMs → Reconciliation on host rebuild](./declarative.md).
+
+### Cleaning up state
+
 If you don't use absolute filesystem paths for sockets, volumes, or
 shares, all MicroVM state is kept under `/var/lib/microvms/$NAME/`.
-The `microvm@.serivce` systemd service template depends on existence
-of this directory.
+The `microvm@.service` systemd service template depends on existence
+of this directory. State is **not** removed automatically, even for
+declarative MicroVMs — clean it up manually:
 
 ```bash
 rm -rf /var/lib/microvms/$NAME

--- a/doc/src/microvm-command.md
+++ b/doc/src/microvm-command.md
@@ -81,18 +81,17 @@ stop the VM:
 systemctl stop microvm@$NAME
 ```
 
-Removing a declaration does **not** automatically stop the running
-service by default. To opt in to that behavior, set
-`microvm.host.stopOrphans = true;` on the host — see
-[Declarative MicroVMs → Reconciliation on host rebuild](./declarative.md).
+Removing a declaration does **not** automatically stop the running service by default.
+To opt in to that behavior, set `microvm.host.stopOrphans = true;` on the host.
+See [Declarative MicroVMs → Reconciliation on host rebuild](./declarative.md) for more information.
 
 ### Cleaning up state
 
 If you don't use absolute filesystem paths for sockets, volumes, or
 shares, all MicroVM state is kept under `/var/lib/microvms/$NAME/`.
 The `microvm@.service` systemd service template depends on existence
-of this directory. State is **not** removed automatically, even for
-declarative MicroVMs — clean it up manually:
+of this directory. State is **never** removed automatically, even for
+declarative MicroVMs — it must be manually cleaned up:
 
 ```bash
 rm -rf /var/lib/microvms/$NAME

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -312,6 +312,24 @@ in
     # Enable Kernel Same-Page Merging
     hardware.ksm.enable = lib.mkDefault true;
 
+    system.activationScripts.microvm-stop-orphans = lib.optionalString config.microvm.host.stopOrphans ''
+      declared=" ${lib.concatStringsSep " " (builtins.attrNames config.microvm.vms)} "
+      if [ -d /run/current-system/etc/systemd/system ]; then
+        for f in /run/current-system/etc/systemd/system/install-microvm-*.service; do
+          [ -e "$f" ] || continue
+          name="$(basename "$f" .service)"
+          name="''${name#install-microvm-}"
+          case "$declared" in
+            *" $name "*) continue ;;
+          esac
+          if ${pkgs.systemd}/bin/systemctl is-active --quiet "microvm@$name.service" 2>/dev/null; then
+            echo "microvm: stopping orphan microvm@$name.service (removed from microvm.vms)" >&2
+            ${pkgs.systemd}/bin/systemctl stop "microvm@$name.service" || true
+          fi
+        done
+      fi
+    '';
+
     # TODO: remove in 2026
     system.activationScripts.microvm-update-check = ''
       if [ -d ${stateDir} ]; then

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -314,7 +314,8 @@ in
 
     system.activationScripts.microvm-stop-orphans = lib.optionalString config.microvm.host.stopOrphans ''
       declared=" ${lib.concatMapAttrsStringSep " " (name: _: name) config.microvm.vms} "
-      for unit in $(systemctl list-unit-files --no-legend 'install-microvm-*.service' 2>/dev/null | awk '{print $1}'); do
+      while read -r unit _; do
+        [ -n "$unit" ] || continue
         name="''${unit#install-microvm-}"
         name="''${name%.service}"
         case "$declared" in
@@ -324,7 +325,7 @@ in
           echo "microvm: stopping orphan microvm@$name.service (removed from microvm.vms)" >&2
           systemctl stop "microvm@$name.service" || true
         fi
-      done
+      done < <(systemctl list-unit-files --no-legend 'install-microvm-*.service' 2>/dev/null)
     '';
 
     # TODO: remove in 2026

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -313,7 +313,7 @@ in
     hardware.ksm.enable = lib.mkDefault true;
 
     system.activationScripts.microvm-stop-orphans = lib.optionalString config.microvm.host.stopOrphans ''
-      declared=" ${lib.concatStringsSep " " (builtins.attrNames config.microvm.vms)} "
+      declared=" ${lib.concatMapAttrsStringSep " " (name: _: name) config.microvm.vms} "
       if [ -d /run/current-system/etc/systemd/system ]; then
         for f in /run/current-system/etc/systemd/system/install-microvm-*.service; do
           [ -e "$f" ] || continue
@@ -322,9 +322,9 @@ in
           case "$declared" in
             *" $name "*) continue ;;
           esac
-          if ${pkgs.systemd}/bin/systemctl is-active --quiet "microvm@$name.service" 2>/dev/null; then
+          if ${lib.getExe' config.systemd.package "systemctl"} is-active --quiet "microvm@$name.service" 2>/dev/null; then
             echo "microvm: stopping orphan microvm@$name.service (removed from microvm.vms)" >&2
-            ${pkgs.systemd}/bin/systemctl stop "microvm@$name.service" || true
+            ${lib.getExe' config.systemd.package "systemctl"} stop "microvm@$name.service" || true
           fi
         done
       fi

--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -314,20 +314,17 @@ in
 
     system.activationScripts.microvm-stop-orphans = lib.optionalString config.microvm.host.stopOrphans ''
       declared=" ${lib.concatMapAttrsStringSep " " (name: _: name) config.microvm.vms} "
-      if [ -d /run/current-system/etc/systemd/system ]; then
-        for f in /run/current-system/etc/systemd/system/install-microvm-*.service; do
-          [ -e "$f" ] || continue
-          name="$(basename "$f" .service)"
-          name="''${name#install-microvm-}"
-          case "$declared" in
-            *" $name "*) continue ;;
-          esac
-          if ${lib.getExe' config.systemd.package "systemctl"} is-active --quiet "microvm@$name.service" 2>/dev/null; then
-            echo "microvm: stopping orphan microvm@$name.service (removed from microvm.vms)" >&2
-            ${lib.getExe' config.systemd.package "systemctl"} stop "microvm@$name.service" || true
-          fi
-        done
-      fi
+      for unit in $(systemctl list-unit-files --no-legend 'install-microvm-*.service' 2>/dev/null | awk '{print $1}'); do
+        name="''${unit#install-microvm-}"
+        name="''${name%.service}"
+        case "$declared" in
+          *" $name "*) continue ;;
+        esac
+        if systemctl is-active --quiet "microvm@$name.service"; then
+          echo "microvm: stopping orphan microvm@$name.service (removed from microvm.vms)" >&2
+          systemctl stop "microvm@$name.service" || true
+        fi
+      done
     '';
 
     # TODO: remove in 2026

--- a/nixos-modules/host/options.nix
+++ b/nixos-modules/host/options.nix
@@ -27,6 +27,27 @@
       '';
     };
 
+    host.stopOrphans = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        When a MicroVM is removed from `microvm.vms.<name>` and
+        `nixos-rebuild switch` is run, stop the running
+        `microvm@<name>.service` instance. This matches the behavior
+        of ordinary `systemd.services.<name>` on config removal.
+
+        Only affects VMs that were previously declared in
+        `microvm.vms` (detected via the presence of
+        `install-microvm-<name>.service` in the previous generation).
+        Imperative MicroVMs managed via the `microvm` command are
+        never touched.
+
+        State under `/var/lib/microvms/<name>/` is never removed.
+        Defaults to `false` to preserve existing behavior; set to
+        `true` to opt in to reconciliation.
+      '';
+    };
+
     vms = mkOption {
       type = with types; attrsOf (submodule ({ config, name, ... }: {
         options = {


### PR DESCRIPTION
## Summary

Closes the reconciliation gap where `nixos-rebuild switch` does not stop a `microvm@<name>.service` after `<name>` is removed from `microvm.vms`. Addresses the stop-on-removal goal from #302 (@astro: *""I'd accept PRs that stop declarative VMs on removal""*), scoped to stopping only — state under `/var/lib/microvms/<name>/` is preserved per the same comment.

Tracked as #508.

**Opt-in by default.** New behavior is gated behind `microvm.host.stopOrphans` which defaults to `false` — existing users see no change. Users who want NixOS-style reconciliation for their declarative VMs set `microvm.host.stopOrphans = true;`.

## Why `restartIfChanged` / the prior #302 discussion doesn't cover this

The fix briefly discussed in #302 (flipping `restartIfChanged` to match `oci-containers`) never shipped, and would not have fixed this bug. `X-RestartIfChanged` controls **restart on config change**; stop-on-removal is a separate path in `switch-to-configuration-ng` (`collect_unit_changes`, `src/main.rs:1078-1089`) that checks whether the service's *base unit file* disappeared.

For `microvm@<name>.service`, the base unit file is the template `microvm@.service`, which the host module unconditionally defines at `nixos-modules/host/default.nix:240`. So `new_base_unit_file` always exists and the stop-on-removal branch never fires — regardless of `restartIfChanged`. The `.wants` symlinks under `microvms.target.wants/` are not examined either (no references in the Rust source).

`microvm.vms.<name>.restartIfChanged` already exists as a per-VM option (#104, #110); that half of the #302 agreement effectively landed. The stop-on-removal half is the remaining gap.

## What this PR does

Adds `system.activationScripts.microvm-stop-orphans` to `nixos-modules/host/default.nix`. When enabled, on each activation it:

1. Lists `install-microvm-*.service` files in `/run/current-system/etc/systemd/system/` — these are the VMs that were declarative in the previous generation.
2. For each, checks if its `<name>` is still in `attrNames config.microvm.vms` of the new generation.
3. If not, and `microvm@<name>.service` is currently active, calls `systemctl stop microvm@<name>.service`.

Using `install-microvm-<name>.service` as the declarative-VM marker is important: imperative VMs managed via the `microvm` command have no `install-microvm-<name>.service` unit, so they are never touched by this reconciliation.

## What this PR explicitly does NOT do

- Does **not** change default behavior — opt-in via `microvm.host.stopOrphans = true;`.
- Does **not** remove `/var/lib/microvms/<name>/` or any VM state, matching the concern in [#302](https://github.com/microvm-nix/microvm.nix/issues/302#issuecomment-2549214467). State cleanup remains manual, as documented in `doc/src/microvm-command.md`.
- Does **not** affect imperative MicroVMs, since they lack the `install-microvm-<name>.service` marker.
- Does **not** touch `Restart=always`, `restartIfChanged`, or any other lifecycle semantics.

## Files changed

- `nixos-modules/host/default.nix` — new activation script (16 lines, inert when the option is `false`).
- `nixos-modules/host/options.nix` — new `microvm.host.stopOrphans` option (default `false`).
- `doc/src/declarative.md` — new ""Reconciliation on host rebuild"" section, framed as opt-in.
- `doc/src/microvm-command.md` — split ""Removing MicroVMs"" into Imperative / Declarative / State cleanup subsections; declarative path mentions the opt-in.

## Test plan

I don't have a NixOS test host to iterate on, and local evaluation of the full flake checks exhausts my machine's memory, so this relies on CI. Happy to add a nixosTest in a follow-up — the natural shape is to declare two VMs with `microvm.host.stopOrphans = true;`, switch to a specialisation that drops one, and assert `microvm@<dropped>.service` is inactive while `/var/lib/microvms/<dropped>/` remains.

- [ ] CI evaluation passes
- [ ] Manual verification on a NixOS host with `microvm.host.stopOrphans = true;` set
- [ ] nixosTest added in follow-up (if desired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)