### PR TITLE
vfkit: use `virtualisation.rosetta` instead of manual set up

### DIFF
--- a/nixos-modules/microvm/rosetta.nix
+++ b/nixos-modules/microvm/rosetta.nix
@@ -1,19 +1,4 @@
-{ config, lib, pkgs, ... }:
-
-let
-  cfg = config.microvm.vfkit.rosetta;
-  mountPoint = "/run/rosetta";
-  mountTag = "rosetta";
-in
-lib.mkIf (config.microvm.hypervisor == "vfkit" && cfg.enable) {
-  fileSystems.${mountPoint} = {
-    device = mountTag;
-    fsType = "virtiofs";
-  };
-
-  boot.binfmt.registrations.rosetta = {
-    interpreter = "${mountPoint}/rosetta";
-    magicOrExtension = ''\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00'';
-    mask = ''\xff\xff\xff\xff\xff\xfe\xfe\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff'';
-  };
+{ config, lib, ... }:
+lib.mkIf (config.microvm.hypervisor == "vfkit" && config.microvm.vfkit.rosetta.enable) {
+  virtualisation.rosetta.enable = true;
 }

--- a/nixos-modules/microvm/rosetta.nix
+++ b/nixos-modules/microvm/rosetta.nix
@@ -1,4 +1,5 @@
 { config, lib, ... }:
+
 lib.mkIf (config.microvm.hypervisor == "vfkit" && config.microvm.vfkit.rosetta.enable) {
   virtualisation.rosetta.enable = true;
 }


### PR DESCRIPTION
Replace manual binfmt configuration with the nixpkgs-provided option. This gives more flexible setup compared to the previous implementation.