### PR TITLE
crosvm runner: drop --seccomp-log-failures version-gate

### DIFF
--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -76,11 +76,6 @@ in {
         "--vhost-user" "gpu,socket=${graphics.socket}"
       ]
       ++
-      lib.optionals (builtins.compareVersions crosvmPkg.version "107.1" < 0) [
-        # workarounds
-        "--seccomp-log-failures"
-      ]
-      ++
       lib.optionals (pivotRoot != null) [
         "--pivot-root"
         pivotRoot


### PR DESCRIPTION
The crosvm runner adds `--seccomp-log-failures` for any `crosvmPkg` whose version compares less than `\"107.1\"`. nixpkgs's `crosvm` is packaged with `version = \"0-unstable-<date>\"`, which `lib.compareVersions` orders lexically below `\"107.1\"`, so the flag is always injected on upstream-built crosvm.

`--seccomp-log-failures` forces minijail to use text-mode policyparsing instead of the precompiled BPF programs. minijail's text-mode parser does not tolerate the syscall redefinitions present across the bundled `@include` chain (e.g. `block.policy` redefines `ioctl` after `common_device.policy` already declared it). The result: every crosvm launch through this runner aborts at policy compile time with `syscall ioctl redefined here` followed by SIGABRT, before the VM even gets to fork its first device proxy.

Reproducer (host: Linux 7.0.1, glibc 2.42, crosvm packaged from nixos-unstable as `0-unstable-2026-02-13`):

```
$ nix run .#cluster-1v1-uifull-up   # any microvm using `hypervisor = \"crosvm\"`
...
libminijail[N]: compile_file: .../share/policy/x86_64/block.policy(10): syscall ioctl redefined here
libminijail[N]: compile_filter: compile_file() failed
libminijail[N]: failed to compile seccomp filter BPF program in '.../share/policy/x86_64/block_device.policy'
systemd-coredump: Process N (crosvm) of user 1000 terminated abnormally with signal 6/ABRT
```

Drop the workaround. If a user explicitly wants `--seccomp-log-failures` for diagnostics, they can pass it via `microvm.crosvm.extraArgs`.