### PR TITLE
Make crosvm graphics package configurable

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -161,7 +161,7 @@ in {
     fi
   '' + lib.optionalString graphics.enable ''
     rm -f ${graphics.socket}
-    ${pkgs.crosvm}/bin/crosvm device gpu \
+    ${graphics.crosvmPackage}/bin/crosvm device gpu \
       --socket ${graphics.socket} \
       --wayland-sock $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY \
       --params '${builtins.toJSON gpuParams}' \

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -481,6 +481,13 @@ in
       '';
     };
 
+    graphics.crosvmPackage = mkOption {
+      description = "crosvm package to use when running graphics (for cloud-hypervisor and crosvm)";
+      default = pkgs.crosvm;
+      defaultText = literalExpression ''"''${pkgs.crosvm}"'';
+      type = types.package;
+    };
+
     graphics.socket = mkOption {
       type = types.str;
       default = "${hostName}-gpu.sock";


### PR DESCRIPTION
This is useful in case somebody is using a patched version of crosvm graphic package with cloud-hypervisor on host

Useful for overrides when issues like #506 happen