### PR TITLE
kvmtool runner puts the literal "image" as the source for volumes when provided as configuration

### DIFF
--- a/lib/runners/kvmtool.nix
+++ b/lib/runners/kvmtool.nix
@@ -49,12 +49,12 @@ in {
       ++
       lib.optionals balloon [ "--balloon" ]
       ++
-      builtins.concatMap ({ serial, direct, readOnly, ... }:
+      builtins.concatMap ({ image, serial, direct, readOnly, ... }:
         lib.warnIf (serial != null) ''
           Volume serial is not supported for kvmtool
         ''
         [ "-d"
-          (lib.escapeShellArg "image${
+          (lib.escapeShellArg "${image}${
             lib.optionalString direct ",direct"
           }${
             lib.optionalString readOnly ",ro"


### PR DESCRIPTION
Looks like this was probably a typo. Found when testing KVM machines