### PR TITLE
fix: x86_64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,10 +27,12 @@
       apps = forAllSystems (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          guestSystem = if nixpkgs.lib.hasSuffix "-darwin" system then nixpkgs.lib.replaceString "-darwin" "-linux" system else system;
           nixosToApp = configFile: {
             type = "app";
             program = "${(import configFile {
-              inherit self nixpkgs system;
+              inherit self nixpkgs;
+              system = guestSystem;
             }).config.microvm.declaredRunner}/bin/microvm-run";
           };
         in {

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -76,26 +76,31 @@ let
   machineOpts =
     if microvmConfig.qemu.machineOpts != null
     then microvmConfig.qemu.machineOpts
-    else {
-      x86_64-linux = {
-        inherit accel;
-        mem-merge = "on";
-        acpi = "on";
-      } // lib.optionalAttrs (machine == "microvm") {
-        pit = "off";
-        pic = "off";
-        pcie = if requirePci then "on" else "off";
-        rtc = "on";
-        usb = if requireUsb then "on" else "off";
-      };
-      aarch64-linux = {
-        inherit accel;
-        gic-version = "max";
-      };
-      aarch64-darwin = {
-        inherit accel;
-      };
-    }.${system};
+    else
+      let
+        x86MachineOpts = {
+          inherit accel;
+          mem-merge = "on";
+          acpi = "on";
+        } // lib.optionalAttrs (machine == "microvm") {
+          pit = "off";
+          pic = "off";
+          pcie = if requirePci then "on" else "off";
+          rtc = "on";
+          usb = if requireUsb then "on" else "off";
+        };
+      in
+      {
+        x86_64-linux = x86MachineOpts;
+        x86_64-darwin = x86MachineOpts;
+        aarch64-linux = {
+          inherit accel;
+          gic-version = "max";
+        };
+        aarch64-darwin = {
+          inherit accel;
+        };
+      }.${system};
 
   machineConfig = builtins.concatStringsSep "," (
     [ machine ] ++

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -1061,12 +1061,12 @@ in
 
   config = lib.mkMerge [ {
     microvm.qemu.machine =
-      lib.mkIf (pkgs.stdenv.hostPlatform.system == "x86_64-linux") (
+      lib.mkIf (lib.elem pkgs.stdenv.hostPlatform.system [ "x86_64-linux" "x86_64-darwin" ]) (
         lib.mkDefault "microvm"
       );
   } {
     microvm.qemu.machine =
-      lib.mkIf (pkgs.stdenv.hostPlatform.system == "aarch64-linux") (
+      lib.mkIf (lib.elem pkgs.stdenv.hostPlatform.system [ "aarch64-linux" "aarch64-darwin" ]) (
         lib.mkDefault "virt"
       );
   } ];


### PR DESCRIPTION
the app construction forces a `microvm.qemu.machine` path that is invalid on `x86_64-darwin`, so the app output itself is not safely evaluable as it is