### PR TITLE
change storeDiskErofsFlags defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
   is no longer first copied into the build directory. A mount
   namespace is setup with bubblewrap instead. mkfs.erofs can now run
   multi-threaded.
+* `microvm.storeDiskErofsFlags` no longer includes `-Ededupe` by
+  default, so erofs store disks build multi-threaded by default. This
+  results in a much faster build for a slightly larger image.
+  `-Efragments` is kept as it is compatible with multi-threading. Add
+  `-Ededupe` back to favor small image size over build speed.
 
 ## 0.5.0 (2024-04-06)
 

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -1004,25 +1004,19 @@ in
       description = ''
         Flags to pass to mkfs.erofs
 
-        Omit `"-Efragments"` and `"-Ededupe"` to enable multi-threading.
+        `"-Ededupe"` is omitted by default because it forces single-threaded, slower builds.
+        Add it back if you prefer smaller images over fast, multi-threaded builds.
       '';
       default =
         [ "-zlz4hc" ]
         ++
         lib.optional (kernelAtLeast "5.16") "-Eztailpacking"
         ++
-        lib.optionals (kernelAtLeast "6.1") [
-          # not implemented with multi-threading
-          "-Efragments"
-          "-Ededupe"
-        ];
+        lib.optional (kernelAtLeast "6.1") "-Efragments";
       defaultText = lib.literalExpression ''
         [ "-zlz4hc" ]
           ++ lib.optional (kernelAtLeast "5.16") "-Eztailpacking"
-          ++ lib.optionals (kernelAtLeast "6.1") [
-          "-Efragments"
-          "-Ededupe"
-        ]
+          ++ lib.optional (kernelAtLeast "6.1") "-Efragments"
         '';
     };
 

--- a/nixos-modules/microvm/store-disk.nix
+++ b/nixos-modules/microvm/store-disk.nix
@@ -6,16 +6,16 @@ let
   };
 
   erofs-utils =
-    # Are any extended options specified?
-    if lib.any (with lib; flip elem ["-Ededupe" "-Efragments"]) config.microvm.storeDiskErofsFlags
+    # Is deduplication option specified?
+    if lib.elem "-Ededupe" config.microvm.storeDiskErofsFlags
     then
-      # If extended options are present,
-      # stick to the single-threaded erofs-utils
-      # to not scare anyone with warning messages.
+      # If specified, stick to the single-threaded erofs-utils
+      # to not scare anyone with warning messages. mkfs.erofs
+      # has no multi-threaded -Ededupe, so it forces
+      # single-threaded compression.
       pkgs.buildPackages.erofs-utils
     else
-      # If no extended options are configured,
-      # rebuild mkfs.erofs with multi-threading.
+      # Otherwise rebuild mkfs.erofs with multi-threading.
       pkgs.buildPackages.erofs-utils.overrideAttrs (attrs: {
         configureFlags = attrs.configureFlags ++ [
           "--enable-multithreading"


### PR DESCRIPTION
## Enable multi-threaded erofs store-disk builds by default (drop `-Ededupe`)

Fixes #535.

Given that:

- `mkfs.erofs` supports multi-threading with `-Efragments`.
- Only `-Ededupe` disables multi-threading in `mkfs.erofs`.
- Enabling multi-threading and disabling dedupe, huge improves times for large closures (~50x speedup on ~3GB closure)
- `-Ededupe` only gives marginal size improvements (-3% size on a ~3GB closure)

It makes sense to REMOVE `-Ededupe` from the default flags which will:

- disable deduplication
- enable multi-threading by default

**Why keep `-Efragments`?** The original issue proposed dropping *both* flags. But `-Efragments` is compatible with multi-threading and its fragment-level dedup recovers most of the image-size savings. It's strictly better than dropping both.

## Measurements

_as measured on a 32-core host (erofs-utils 1.9.1)_

### Build time (duration of `mkfs.erofs`)

| closure (VM) | current<br>(`-Ededupe -Efragments`) | no extended flags | this PR<br>(`-Efragments`) |
|---|---|---|---|
| small | 31.8 s | 2.8 s | 3.0 s |
| medium | 68.7 s | 3.9 s | 4.3 s |
| large | 420.0 s | 7.7 s | 7.9 s |

### Store-disk image size

| closure | current<br>(`-Ededupe -Efragments`) | no extended flags | this PR<br>(`-Efragments`) |
|---|---|---|---|
| small | 585 MiB | 605 MiB (+19 MiB, +3.3%) | 595 MiB (+10 MiB, +1.7%) |
| medium | 1215 MiB | 1244 MiB (+28 MiB, +2.3%) | 1229 MiB (+14 MiB, +1.1%) |
| large | 3091 MiB | 3306 MiB (+215 MiB, +6.9%) | 3182 MiB (+91 MiB, +2.9%) |
