### PR TITLE
qemu: only advertise mq=on for multi-queue backends (tap, macvtap)

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -339,11 +339,10 @@ lib.warnIf (mem == 2048) ''
             (microvmConfig.cpu == null && system != "x86_64-linux")
           ) ",romfile="
         }${
-          # mq=on needs a backend with matching queues: tap gets
-          # queues=N on the netdev above, macvtap opens one fd per
-          # queue. user (SLIRP) and bridge-helper netdevs are
-          # single-queue -- advertising VIRTIO_NET_F_MQ there makes the
-          # guest steer flows onto queues the backend never services,
+          # mq=on needs a backend with matching queues:
+          # tap gets queues=N on the netdev above, macvtap opens one fd per queue.
+          # user (SLIRP) and bridge-helper netdevs are single-queue -- advertising VIRTIO_NET_F_MQ
+          # there makes the guest steer flows onto queues the backend never services,
           # so inbound hostfwd connections stall.
           lib.optionalString (
             (type == "tap" || type == "macvtap") && tapMultiQueue && requirePci

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -339,7 +339,15 @@ lib.warnIf (mem == 2048) ''
             (microvmConfig.cpu == null && system != "x86_64-linux")
           ) ",romfile="
         }${
-          lib.optionalString (tapMultiQueue && requirePci) ",mq=on,vectors=${toString (2 * vcpu + 2)}"
+          # mq=on needs a backend with matching queues: tap gets
+          # queues=N on the netdev above, macvtap opens one fd per
+          # queue. user (SLIRP) and bridge-helper netdevs are
+          # single-queue -- advertising VIRTIO_NET_F_MQ there makes the
+          # guest steer flows onto queues the backend never services,
+          # so inbound hostfwd connections stall.
+          lib.optionalString (
+            (type == "tap" || type == "macvtap") && tapMultiQueue && requirePci
+          ) ",mq=on,vectors=${toString (2 * vcpu + 2)}"
         }"
       ]) interfaces
     )


### PR DESCRIPTION
## Problem

`lib/runners/qemu.nix` appends `,mq=on,vectors=${2*vcpu+2}` to every `-device virtio-net-*` line whenever `tapMultiQueue = vcpu > 1` and PCI is available — regardless of the interface's backend type.

For `type = "tap"` the netdev also gets `queues=N`, and macvtap opens one fd per queue, so the flag is correct there. But `type = "user"` (SLIRP) and `type = "bridge"` (bridge-helper tap) backends are single-queue: advertising `VIRTIO_NET_F_MQ` makes the guest driver enable multiple queue pairs and steer flows onto queues the backend never services.

## Observed effect

`type = "user"` microvm, `vcpu = 2`, two `forwardPorts` (ssh + an HTTP API), QEMU 10.2.2 / libslirp 4.9.1:

- the SSH forward works;
- the HTTP forward accepts TCP on the host, but the guest receives the forwarded SYNs only in delayed bursts (tens of seconds late, flushed by unrelated connection events) — clients time out every time. Guest-side `TcpPassiveOpens` / NIC rx counters confirm the SYNs arrive late rather than never.

Dropping `mq=on` from the user-netdev device line restores normal hostfwd delivery.

## Fix

Gate the fragment on `(type == "tap" || type == "macvtap") && tapMultiQueue && requirePci`. Single-queue backends now get a plain virtio-net device; tap/macvtap keep real multiqueue. Follows up on #199, which fixed the non-PCI half of this condition.