### PR TITLE
virtiofs: fix supervisord event queue buffer size

### DIFF
--- a/nixos-modules/microvm/virtiofsd/default.nix
+++ b/nixos-modules/microvm/virtiofsd/default.nix
@@ -22,6 +22,8 @@ in
           };
 
           "eventlistener:notify" = {
+            # Increase the event queue buffer size such that we don't drop RUNNING events while the event handler hasn't started up yet
+            buffer_size = (1 + builtins.length virtiofsShares) * 16;
             command = pkgs.writers.writePython3 "supervisord-event-handler" { } (
               pkgs.replaceVars  ./supervisord-event-handler.py {
                 # 1 for the event handler process


### PR DESCRIPTION
supervisord queues its events in a buffer as long as the event listener process (supervisord-event-handler) is not ready to process them, for instance because it hasn't fully started up yet. When this buffer overflows, the oldest event is discarded [^1]. The default size of this buffer is 10 [^2]. In the setup used here in microvm, the event listener python script typically takes more than one second to start up (at least on my machine), which means that all RUNNING events are emitted before the event listener is ready to process them. This means if the number of virtiofs shares is greater than 9, some RUNNING events will be discarded, and the systemd notify message will not be sent, causing the microvm-virtiofsd@ service to hang and thus preventing the VM from starting.

This commit fixes this bug by setting `buffer_size` to `(1 + builtins.length virtiofsShares) * 16`. The factor of 16 is to account for the possibility that some of the virtiofs processes might crash and then start again.

Tested on my personal microvm setup.

[^1]: https://supervisord.org/configuration.html#eventlistener-x-section-values
[^2]: https://github.com/Supervisor/supervisor/blob/abc60468ea4b78c446cf3a194f6fccb83d90f670/supervisor/options.py#L737