### PR TITLE
Fix the executable path in run-waypipe

### DIFF
--- a/nixos-modules/microvm/graphics.nix
+++ b/nixos-modules/microvm/graphics.nix
@@ -11,7 +11,7 @@ let
   '';
   # Waypipe. Needs `microvm#waypipe-client` on the host.
   run-waypipe = with pkgs; writeShellScriptBin "run-waypipe" ''
-    exec ${lib.getExe waypipe}/bin/waypipe --vsock -s 2:6000 server $@
+    exec ${lib.getExe waypipe} --vsock -s 2:6000 server $@
   '';
 in
 lib.mkIf config.microvm.graphics.enable {


### PR DESCRIPTION
The bin path was added twice:
```shell
[vm@nixos:~]$ run-waypipe 
/run/current-system/sw/bin/run-waypipe: line 2: /nix/store/8gzmq3wh3sig66mbns019qz96ab0cyh3-waypipe-0.11.0/bin/waypipe/bin/waypipe: Not a directory
```
