### PR TITLE
cloud-hypervisor: merge user --cpus from extraArgs with generated boot=

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -16,7 +16,7 @@ let
   processedExtraArgs = builtins.foldl'
     (args: opt: (extractOptValues opt args).args)
     extraArgs
-    ["--vsock" "--platform"];
+    ["--vsock" "--platform" "--cpus"];
 
   hasUserConsole = (extractOptValues "--console" extraArgs).values != [];
   hasUserSerial = (extractOptValues "--serial" extraArgs).values != [];
@@ -144,6 +144,14 @@ let
     else
       lib.concatStringsSep "," (oemStringOptions ++ userPlatformOpts);
 
+  userCpusOpts = (extractOptValues "--cpus" extraArgs).values;
+  userCpusBoot = extractParamValue "boot" (lib.concatStringsSep "," userCpusOpts);
+  cpusOps =
+    if userCpusBoot != null then
+      throw "Cannot set `microvm.vcpu` and --cpus 'boot=${userCpusBoot}...' via `microvm.cloud-hypervisor.extraArgs` at the same time"
+    else
+      lib.concatStringsSep "," ([ "boot=${toString vcpu}" ] ++ userCpusOpts);
+
   cloudhypervisorPkg = microvmConfig.cloud-hypervisor.package;
 in {
   inherit tapMultiQueue supportsNotifySocket;
@@ -187,7 +195,7 @@ in {
     else lib.escapeShellArgs (
       [
         "${cloudhypervisorPkg}/bin/cloud-hypervisor"
-        "--cpus" "boot=${toString vcpu}"
+        "--cpus" cpusOps
         "--watchdog"
         "--kernel" kernelPath
         "--initramfs" initrdPath


### PR DESCRIPTION
Closes #157.

Exposes the rest of cloud-hypervisor's --cpus parameters through microvm.cloud-hypervisor.extraArgs. The runner hardcodes --cpus boot=N from microvm.vcpu, and clap rejects a repeated --cpus flag, so until now no other CPU parameter could be passed.

Extract --cpus from extraArgs and merge its parameters with the generated boot=, following the existing --vsock and --platform handling. boot= in extraArgs is an eval-time error, matching the --vsock cid check.