### PR TITLE
Add headless QEMU graphics backend

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -246,6 +246,9 @@ lib.warnIf (mem == 2048) ''
            gtk = [
              "-display" "gtk,gl=on" "-device" "virtio-vga-gl"
            ];
+           headless = [
+             "-display" "egl-headless" "-device" "virtio-gpu-gl"
+           ];
          }.${graphics.backend};
        in
          displayArgs ++ [

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -584,10 +584,11 @@ in
         description = ''
           Enable GUI support.
 
-          MicroVMs with graphics are intended for the interactive
-          use-case. They cannot be started through systemd jobs.
-
-          The display backend is chosen by `microvm.graphics.backend`.
+          The graphics backend is chosen by `microvm.graphics.backend`.
+          The `gtk` and `cocoa` backends are intended for the interactive
+          use-case and cannot be started through systemd jobs.
+          The `headless` backend can be started through a systemd job
+          as it does not open a host window.
         '';
       };
 
@@ -599,7 +600,7 @@ in
       };
 
       backend = mkOption {
-        type = types.enum [ "gtk" "cocoa" ];
+        type = types.enum [ "gtk" "cocoa" "headless" ];
         default = if pkgs.stdenv.hostPlatform.isDarwin then "cocoa" else "gtk";
         defaultText = lib.literalExpression ''if pkgs.stdenv.hostPlatform.isDarwin then "cocoa" else "gtk"'';
         description = ''


### PR DESCRIPTION
Adds `headless` to QEMU graphics backend options with `-display egl-headless -device virtio-gpu-gl`.
Now it is possible to run a graphical microVM as a systemd service.

Unlike `gtk`, `egl-headless` doesn't open a host window. As we don't have a window anymore I thought it should use `virtio-gpu-gl` instead of `virtio-vga-gl`.  I don't know much about virtio devices. So I'm mostly going by my testing. 

I tested it with `glmark2` and `waydroid`. It's working correctly over `waypipe` and seems to be gpu accelerated.
