### PR TITLE
Drop x86_64-darwin from systems

### DIFF
--- a/.github/workflows/prebuilt-stable.yml
+++ b/.github/workflows/prebuilt-stable.yml
@@ -1,4 +1,4 @@
-name: "prebuilt-25.11"
+name: "prebuilt-26.05"
 
 on:
   workflow_dispatch: # allows manual triggering

--- a/doc/src/faq.md
+++ b/doc/src/faq.md
@@ -139,7 +139,7 @@ individually used block devices.
 On macOS, **microvm.nix** uses the `vfkit` hypervisor to run Linux
 guests through Apple's native Virtualization.framework. While vfkit
 itself runs natively on macOS, the guest NixOS system still has to be
-built for Linux, and `aarch64-darwin` / `x86_64-darwin` cannot compile
+built for Linux, and `aarch64-darwin` cannot compile
 or cross compile those. You therefore need access to a Linux
 builder. Without one, `nix run` will fail with errors like:
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,6 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
     in {

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -93,7 +93,6 @@ let
       in
       {
         x86_64-linux = x86MachineOpts;
-        x86_64-darwin = x86MachineOpts;
         aarch64-linux = {
           inherit accel;
           gic-version = "max";

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -1056,7 +1056,7 @@ in
 
   config = lib.mkMerge [ {
     microvm.qemu.machine =
-      lib.mkIf (lib.elem pkgs.stdenv.hostPlatform.system [ "x86_64-linux" "x86_64-darwin" ]) (
+      lib.mkIf (lib.elem pkgs.stdenv.hostPlatform.system [ "x86_64-linux" ]) (
         lib.mkDefault "microvm"
       );
   } {


### PR DESCRIPTION
CI fails to build on main because `x86_64-darwin` support has ended.
Opened this as draft as there are other places that `x86_64-darwin` is used that could be removed.
I also wasn't sure if you want to drop `x86_64-darwin` or pin the input.