### PR TITLE
virtiofs: add per-share posixAcl and extraArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   `microvm.virtiofsd.group` and
   `microvm.virtiofsd.inodeFileHandles` and
   `microvm.virtiofsd.threadPoolSize` now.
+* Per-share virtiofsd options: `microvm.shares.*.posixAcl` and
+  `.extraArgs`, enabling per-share UID/GID remapping via
+  `--translate-uid` / `--translate-gid`.
 * Add the [alioth VMM](https://github.com/google/alioth)
 * Fixes for the stratovirt VMM
 * New volume image files will be created with `truncate` instead of

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -92,6 +92,31 @@ let
         };
       }) ];
     } ]
+    # virtiofs per-share options (posixAcl + extraArgs)
+    [ {
+      # no virtiofs share
+      id = null;
+    } {
+      id = "virtiofs";
+      modules = [ ({ config, ... }: {
+        microvm = {
+          shares = [ {
+            proto = "virtiofs";
+            tag = "test";
+            source = "/nix/store";
+            mountPoint = "/nix/.ro-store";
+            # Exercise the new per-share options: posix-acl must be off
+            # because --translate-uid conflicts with it.
+            posixAcl = false;
+            extraArgs = [ "--translate-uid" "guest:0:0:1" ];
+          } ];
+          testing.enableTest = builtins.elem config.microvm.hypervisor [
+            # Hypervisors that use virtiofsd
+            "qemu" "cloud-hypervisor" "crosvm"
+          ];
+        };
+      }) ];
+    } ]
     # rw-store
     [ {
       # none

--- a/doc/src/shares.md
+++ b/doc/src/shares.md
@@ -42,6 +42,37 @@ have options
 </div>
 
 
+## Per-share virtiofsd options
+
+Each `virtiofs` share also supports:
+
+- **`posixAcl`** (bool, default `true`): pass `--posix-acl --xattr`.
+  Set to `false` to use `--translate-uid`/`--translate-gid`.
+- **`extraArgs`** (list of strings, default `[]`): extra virtiofsd
+  arguments for this share, appended after the global
+  `microvm.virtiofsd.extraArgs`.
+
+Example: map guest uid 999 to host uid 1000 for a single share:
+
+```nix
+microvm.shares = [ {
+  proto = "virtiofs";
+  tag = "hermes-prompts";
+  source = "/var/lib/vibe-nix/hermes";
+  mountPoint = "/run/hermes/prompts";
+  posixAcl = false;
+  extraArgs = [
+    "--translate-uid" "guest:999:1000:1"
+    "--translate-gid" "guest:999:1000:1"
+  ];
+} ];
+```
+
+`--translate-uid guest:GUEST_UID:HOST_UID:COUNT` remaps
+`[GUEST_UID, GUEST_UID+COUNT)` in the guest to
+`[HOST_UID, HOST_UID+COUNT)` on the host.
+
+
 ## Sharing a host's `/nix/store`
 
 If a share with `source = "/nix/store"` is defined, size and build

--- a/nixos-modules/microvm/asserts.nix
+++ b/nixos-modules/microvm/asserts.nix
@@ -95,6 +95,25 @@ lib.mkIf config.microvm.guest.enable {
         config.microvm.shares
     )
     ++
+    # check for virtiofs shares where posixAcl conflicts with translate-uid/gid
+    # (--posix-acl and --translate-uid/--translate-gid are mutually exclusive in virtiofsd;
+    # --translate-uid/gid can come from either per-share extraArgs or global microvm.virtiofsd.extraArgs)
+    map ({ tag, posixAcl, extraArgs, ... }: {
+      assertion = !(posixAcl && (
+        lib.any (s: lib.hasInfix "--translate-uid" s || lib.hasInfix "--translate-gid" s)
+          (config.microvm.virtiofsd.extraArgs ++ extraArgs)
+      ));
+      message = ''
+        MicroVM ${hostName}: virtiofs share "${tag}" has posixAcl=true but
+        extraArgs (per-share or global microvm.virtiofsd.extraArgs) contains
+        --translate-uid/--translate-gid, which conflict with --posix-acl.
+        Set posixAcl=false on this share to use UID/GID remapping.
+      '';
+    }) (
+      builtins.filter ({ proto, ... }: proto == "virtiofs")
+        config.microvm.shares
+    )
+    ++
     # blacklist forwardPorts
     [ {
       assertion =

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -420,7 +420,8 @@ in
             default = true;
             description = ''
               Pass `--posix-acl --xattr` to virtiofsd. Disable when using
-              `--translate-uid`/`--translate-gid` (they conflict with `--posix-acl`).
+              `--translate-uid`/`--translate-gid` (asserted to be mutually exclusive
+              with `--posix-acl`, see asserts.nix).
             '';
           };
           extraArgs = mkOption {

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -415,6 +415,19 @@ in
             description = "Virtiofs caching policy for the file system, ignored when 9p is used";
             default = "auto";
           };
+          posixAcl = mkOption {
+            type = bool;
+            default = true;
+            description = ''
+              Pass `--posix-acl --xattr` to virtiofsd. Disable when using
+              `--translate-uid`/`--translate-gid` (they conflict with `--posix-acl`).
+            '';
+          };
+          extraArgs = mkOption {
+            type = listOf str;
+            default = [];
+            description = "Extra arguments passed to virtiofsd for this share.";
+          };
         };
       }));
     };

--- a/nixos-modules/microvm/virtiofsd/default.nix
+++ b/nixos-modules/microvm/virtiofsd/default.nix
@@ -33,7 +33,7 @@ in
             events = "PROCESS_STATE";
           };
         } // builtins.listToAttrs (
-          map ({ tag, socket, source, readOnly, cache, ... }: {
+          map ({ tag, socket, source, readOnly, cache, posixAcl, extraArgs, ... }: {
             name = "program:virtiofsd-${tag}";
             value = {
               stderr_syslog = true;
@@ -52,7 +52,7 @@ in
                   --shared-dir=${lib.escapeShellArg source} \
                   $OPT_RLIMIT \
                   --thread-pool-size ${toString config.microvm.virtiofsd.threadPoolSize} \
-                  --posix-acl --xattr \
+                  ${lib.optionalString posixAcl "--posix-acl --xattr"} \
                   --cache=${cache} \
                   ${lib.optionalString (config.microvm.virtiofsd.inodeFileHandles != null)
                     "--inode-file-handles=${config.microvm.virtiofsd.inodeFileHandles}"
@@ -61,7 +61,8 @@ in
                     "--tag=${tag}"
                   } \
                   ${lib.optionalString readOnly "--readonly"} \
-                  ${lib.concatStringsSep " " config.microvm.virtiofsd.extraArgs}
+                  ${lib.concatStringsSep " " config.microvm.virtiofsd.extraArgs} \
+                  ${lib.concatStringsSep " " extraArgs}
               '';
             };
           }) virtiofsShares


### PR DESCRIPTION
virtiofsd supports UID/GID remapping via `--translate-uid`/`--translate-gid`, but those conflict with `--posix-acl`, which microvm.nix hard-codes for every virtiofs share. The global `microvm.virtiofsd.extraArgs` is also insufficient because it applies to all shares. This PR makes both flags per-share, so an individual share can opt out of `--posix-acl` and pass `--translate-uid`.

Two new attributes on each `virtiofs` share entry (naming follows the existing `readOnly` style — direct noun, not `enableX`):

- `posixAcl` (bool, default `true`): toggle `--posix-acl --xattr`
- `extraArgs` (list of strings, default `[]`): per-share virtiofsd args, appended after the global `microvm.virtiofsd.extraArgs`

Both default to values that produce identical virtiofsd argv for existing configs. See `doc/src/shares.md` "Per-share virtiofsd options" for a usage example (UID/GID remapping across host/guest boundary).

Verified by inspecting the generated supervisord config for two shares in the same VM: default share still emits `--posix-acl --xattr` (unchanged), and a share with `posixAcl = false; extraArgs = ["--translate-uid" "guest:999:1000:1"]` correctly emits `--translate-uid` without `--posix-acl`. Also confirmed `virtiofsd` itself starts successfully with that invocation. Added a `virtiofs` variant to `checks/default.nix` exercising both new options.