### PR TITLE
Add QEMU virtio-gpu Vulkan options

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -239,15 +239,20 @@ lib.warnIf (mem == 2048) ''
     ] ++
        (if graphics.enable then (
        let
+         vulkanArgs = lib.optionals (graphics.vulkan != null) [
+          "blob=true"
+          "hostmem=${graphics.hostmem}"
+          "${graphics.vulkan}=on"
+         ];
          displayArgs = {
            cocoa = [
              "-display" "cocoa" "-device" "virtio-gpu"
            ];
            gtk = [
-             "-display" "gtk,gl=on" "-device" "virtio-vga-gl"
+             "-display" "gtk,gl=on" "-device" (lib.concatStringsSep "," ([ "virtio-vga-gl" ] ++ vulkanArgs))
            ];
            headless = [
-             "-display" "egl-headless" "-device" "virtio-gpu-gl"
+             "-display" "egl-headless" "-device" (lib.concatStringsSep "," ([ "virtio-gpu-gl" ] ++ vulkanArgs))
            ];
          }.${graphics.backend};
        in

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -617,6 +617,23 @@ in
           Path of vhost-user socket
         '';
       };
+
+      vulkan = mkOption {
+        type = with types; nullOr (enum [ "venus" "drm_native_context" ]);
+        default = null;
+        description = ''
+          QEMU Vulkan translation protocol to use for enabling virtio-gpu Vulkan support.
+        '';
+      };
+
+      hostmem = mkOption {
+        type = types.str;
+        default = "256M";
+        description = ''
+          Size of the QEMU virtio-gpu host memory window, typically between 256M and 8G.
+          The value must include a unit suffix (M or G).
+        '';
+      };
     };
 
     vmHostPackages = mkOption {


### PR DESCRIPTION
Adds support for vulkan translation layers on QEMU.
https://www.qemu.org/docs/master/system/devices/virtio/virtio-gpu.html