### PR TITLE
cloud-hypervisor: lower notify socat timeout so guest PID1 isn't stalled 2s per sd_notify

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -170,9 +170,21 @@ in {
 
     # Start socat to forward systemd notify socket over vsock
     if [ -n "''${NOTIFY_SOCKET:-}" ]; then
-      # -T2 is required because cloud-hypervisor does not handle partial
-      # shutdown of the stream, like systemd v256+ does.
-      ${pkgs.socat}/bin/socat -T2 UNIX-LISTEN:${vsockPath}_8888,fork UNIX-SENDTO:$NOTIFY_SOCKET &
+      # Both timeouts must be short: since systemd v256, every sd_notify()
+      # over an AF_VSOCK stream socket blocks in recv() until the peer
+      # closes, and guest PID1 sends STATUS= notifications every 333ms while
+      # boot jobs are running - each one stalls PID1's whole event loop
+      # until the guest sees EOF, serializing boot.
+      #
+      # -t0: with cloud-hypervisor >= 53.0 the guest's half-close is
+      #   propagated, so socat sees EOF and must terminate the connection
+      #   immediately instead of waiting its default 0.5s drain timeout
+      #   (there is no reverse traffic to drain - the other side is a
+      #   datagram socket).
+      # -T0.2: with cloud-hypervisor <= 52.0 the half-close is never
+      #   propagated, so only this inactivity timeout closes the connection
+      #   and delivers the EOF.
+      ${pkgs.socat}/bin/socat -t0 -T0.2 UNIX-LISTEN:${vsockPath}_8888,fork UNIX-SENDTO:$NOTIFY_SOCKET &
     fi
   '' + lib.optionalString graphics.enable ''
     rm -f ${graphics.socket}


### PR DESCRIPTION
## Summary

With the cloud-hypervisor runner and notify sockets enabled, guests running systemd ≥ v256 boot (and shut down) pathologically slowly: PID1 dispatches unit-state transitions in metronomic ~2-second steps, inflating a boot that should take a few seconds to 1–2 minutes and pushing `microvm@` toward its start timeout. The socat notify bridge's timeouts are the cause. This PR changes `-T2` to `-t0 -T0.2` and documents why both flags matter.

Measured on NixOS 26.05 guests (systemd 260.2), same host, four VMs (guest userspace per `systemd-analyze`):

| configuration | virtiofs-store guest | EROFS-store guest |
|---|---:|---:|
| CH 52.0, `-T2` (current) | 117 s | 59 s |
| CH 52.0, `-T0.2` | 10.2 s | 8.4 s |
| CH 53.0, `-T0.2` (socat default `-t0.5`) | 18.2 s | 16.4 s |
| CH 53.0, `-t0 -T0.2` (this PR) | **5.7 s** | **3.1 s** |

VM shutdown time also dropped from ~15 s to ~3 s — the same mechanism serializes stop jobs.

## Mechanism

1. The runner passes `io.systemd.credential:vmm.notify_socket=vsock-stream:2:8888` via SMBIOS. Guest PID1 imports it and sets it as **its own** `NOTIFY_SOCKET` (`src/core/import-creds.c`, "Propagate vmm_notify_socket credential → $NOTIFY_SOCKET env var"). So *every* status notification PID1 emits goes to the VMM — not just the final `READY=1`.
2. Since systemd v256 ([systemd#31849](https://github.com/systemd/systemd/issues/31849) added stream-vsock notify support, since AF_VSOCK has no datagram support on these VMMs), each `sd_notify()` over an AF_VSOCK `SOCK_STREAM` socket opens a connection, sends, does `shutdown(SHUT_WR)`, and then **blocks in `recv()` waiting for EOF** (`src/libsystemd/sd-daemon/sd-daemon.c`, the `AF_VSOCK` branch after the send loop; the socket is blocking). EOF is the message delimiter in this protocol, so the sender must wait for it.
3. PID1 notifies constantly during boot: once any job has been running ≥ 2 s, the jobs-in-progress ("cylon") timer fires every 333 ms and sends a `STATUS=` notification on each tick (`src/core/manager.c`: `JOBS_IN_PROGRESS_WAIT_USEC = 2s`, `JOBS_IN_PROGRESS_PERIOD_USEC = 1/3 s`, `manager_print_jobs_in_progress` → `sd_notifyf`). Whenever a single notification blocks longer than that 333 ms period, the timer is due again immediately after each dispatch, and PID1's single-threaded event loop saturates: unit dispatching, D-Bus replies, and sigchld handling serialize at ~one step per blocking interval — for as long as the initial transaction has jobs, i.e. the entire boot.

How long each notification blocks is decided entirely by the socat bridge:

- **cloud-hypervisor ≤ 52.0** does not propagate the guest's half-close to the host unix socket (the reason the existing `-T2` comment exists). socat never sees EOF, so only the `-T` *inactivity* timeout closes the connection: with `-T2`, every notification stalls PID1 for ~2 s.
- **cloud-hypervisor ≥ 53.0** propagates the half-close ([cloud-hypervisor#8372](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8372)), so socat sees EOF — but then waits its default *drain* timeout (`-t`, default 0.5 s) before terminating the connection, so every notification still stalls PID1 for ~0.5 s. Confirmed with strace inside a CH 53 guest: `recvfrom` returned EOF after 0.50–0.56 s, consistently across four VMs — and boots were uniformly ~7 s *slower* than CH 52 with `-T0.2`, because 0.5 s > the 0.2 s inactivity path it replaced.

Observable signature of the bug in an affected guest's journal: PID1 log lines spaced 2.006 ± 0.005 s apart from just after "Acquired 1 regular credentials" until `READY=1`. Second-order damage observed: `user-runtime-dir@.service` taking 50 s (two sequential 25 s D-Bus timeouts against a logind that was itself stuck in synchronous `StartUnit` calls to the starved PID1), and hosts hitting `microvm@`'s start timeout.

## The fix

```
socat -t0 -T0.2 UNIX-LISTEN:...,fork UNIX-SENDTO:$NOTIFY_SOCKET
```

- **`-t0`** (CH ≥ 53 path): terminate immediately when EOF arrives. This is safe because by the time socat's EOF handling runs, the notification payload has already been forwarded to the datagram `$NOTIFY_SOCKET`, and the datagram side can never produce reverse traffic that would need draining. Measured result: the guest's `recv()` gets EOF in **77 µs** (was 501 ms), and a complete concurrent `systemd-notify` round-trip takes 14–59 ms including process startup.
- **`-T0.2`** (CH ≤ 52 fallback): with no half-close ever arriving, the inactivity timeout remains the only EOF source. 0.2 s is safe against message fragmentation: socat forwards each `read()` to the datagram socket immediately (so `-T` only controls when the guest gets its EOF), and systemd writes each notify message in a single `send()` — 200 ms of *inactivity* on a local vsock path cannot split a message. It still costs 0.2 s per notification, but that is below the 333 ms cylon period, so the event loop no longer saturates.

Once the minimum supported cloud-hypervisor version is ≥ 53, the `-T` fallback could be dropped entirely; `-t0` remains correct either way.