### PR TITLE
QEMU graphics does not require the libusb override

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -44,7 +44,6 @@ let
   volumes = withDriveLetters microvmConfig;
 
   requireUsb =
-    graphics.enable ||
     lib.any ({ bus, ... }: bus == "usb") microvmConfig.devices;
 
   arch = builtins.head (builtins.split "-" system);


### PR DESCRIPTION
From my understanding `usb=on` is only required for usb pass-through which is not needed for the graphics module.
`qemu-xhci` emulates a usb controller and it doesn't need `usb=on`.
```nix
         displayArgs ++ [
           "-device" "qemu-xhci"
           "-device" "usb-tablet"
           "-device" "usb-kbd"
         ]
```
Removing the override for graphics, makes the build time much faster.
