### PR TITLE
Fix SSH over vsock when no virtio-PCI devices are available

### DIFF
--- a/nixos-modules/microvm/system.nix
+++ b/nixos-modules/microvm/system.nix
@@ -10,7 +10,6 @@
 
 
     boot.loader.grub.enable = false;
-    # boot.initrd.systemd.enable = lib.mkDefault true;
     boot.initrd.kernelModules = [
       "virtio_mmio"
       "virtio_pci"

--- a/nixos-modules/microvm/system.nix
+++ b/nixos-modules/microvm/system.nix
@@ -27,6 +27,11 @@
       "overlay"
     ];
 
+    boot.initrd.availableKernelModules = [
+      # Fix SSH over vsock when no virtio-PCI devices are available
+      "vmw_vsock_virtio_transport"
+    ];
+
     microvm.kernelParams = let
       # When a store disk is used, we can drop references to the packed contents as the squashfs/erofs contains all paths.
       toplevel = if config.microvm.storeOnDisk then


### PR DESCRIPTION
SSH over `vsock` stops working when I disable the only `virtiofs` share in my example VM (the read-only nix store).
I think `systemd-ssh-generator` fails when a `virtio-pci` device is not present. I'm not sure if this is an upstream issue, but what weird bug :)
Either way, adding `vmw_vsock_virtio_transport` to initrd available kernel modules fixes the issue.

Closes https://github.com/microvm-nix/microvm.nix/issues/512

Before:
```
[vm@nixos:~]$ ss -lnp | grep :22
tcp   LISTEN 0      128                                                   0.0.0.0:22               0.0.0.0:*    
tcp   LISTEN 0      128                                                      [::]:22                  [::]:*    
```
After:
```
[vm@nixos:~]$ ss -lnp | grep :22
tcp   LISTEN 0      128                                                   0.0.0.0:22               0.0.0.0:*         
tcp   LISTEN 0      128                                                      [::]:22                  [::]:*         
v_str LISTEN 0      0                                                           *:22                     *:*         
```