### PR TITLE
qemu: Add missing device type for virtio-balloon

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -262,7 +262,7 @@ lib.warnIf (mem == 2048) ''
     lib.optionals (user != null) [ "-run-with" "user=${user}" ] ++
     lib.optionals (socket != null) [ "-qmp" "unix:${socket},server,nowait" ] ++
     lib.optionals balloon [
-	    "-device" ("virtio-balloon,free-page-reporting=on,id=balloon0" + lib.optionalString (deflateOnOOM) ",deflate-on-oom=on")
+	    "-device" ("virtio-balloon-${devType},free-page-reporting=on,id=balloon0" + lib.optionalString (deflateOnOOM) ",deflate-on-oom=on")
     ] ++
     lib.optionals useHotPlugMemory [
       "-object" "memory-backend-ram,id=vmem0,size=${toString hotplugMem}M"


### PR DESCRIPTION
`microvm.balloon = true;` crashes the VM if no PCI bus is present.
```
Jul 31 05:13:38 t1000 microvm@example-vm[175927]: microvm@nixos: -device virtio-balloon,free-page-reporting=on,id=balloon0,deflate-on-oom=on: No 'PCI' bus found for device 'virtio-balloon-pci'
```

Use `devType` to select the `-device` variant:
```
❯ qemu-system-x86_64 -device help | grep balloon
name "hv-balloon", bus vmbus
name "virtio-balloon-device", bus virtio-bus
name "virtio-balloon-pci", bus PCI, alias "virtio-balloon"
```