### PR TITLE
crosvm: Add balloon page reporting

### DIFF
--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -67,7 +67,11 @@ in {
         "-p" "console=ttyS0 reboot=k panic=1 ${toString microvmConfig.kernelParams}"
       ]
       ++
-      lib.optional (!balloon) "--no-balloon"
+      (
+        if balloon
+        then [ "--balloon-page-reporting" ]
+        else [ "--no-balloon" ]
+      )
       ++
       lib.optionals storeOnDisk [
         "-r" storeDisk


### PR DESCRIPTION
Without page reporting on `crosvm`, memory can only be returned to the host manually.

`--balloon-page-reporting` is `crosvm`'s equivalent of QEMU's `free-page-reporting=on`.