### PR TITLE
Document that -f local flake paths must be absolute

### DIFF
--- a/doc/src/microvm-command.md
+++ b/doc/src/microvm-command.md
@@ -14,6 +14,12 @@ kept in `/var/lib/microvms/*/flake` for future updating the MicroVM.
 microvm -f git+https://... -c my-microvm
 ```
 
+If `-f` points to a local flake, the path must be absolute. `create`
+evaluates the flake from an internal temporary directory, so a
+relative path (including `.`) will not resolve against your shell's
+current working directory and the flake will not be found. Use
+`-f $(pwd)` or a full path instead, e.g. `-f /path/to/flake`.
+
 ### Enabling MicroVM autostart
 
 Extension of the host's systemd units must happen declaratively in the

--- a/pkgs/microvm-command.nix
+++ b/pkgs/microvm-command.nix
@@ -103,6 +103,7 @@ writeShellScriptBin "microvm" ''
 
   Flags:
           -f <flake>  Create using another flake than $FLAKE
+                      (a local path must be absolute)
           -R          Restart after update
   EOF
       ;;


### PR DESCRIPTION
## What

Documents that a local `-f <flake>` path passed to `microvm -c` must be absolute, and adds a one-line clarification to the `-f` help text.

## Why

As you noted on #538: `create)` builds from an internal `mktemp -d` scratch directory (`pkgs/microvm-command.nix`), so a relative `-f` path (e.g. `-f .`) resolves against that temp dir instead of the caller's CWD and fails with `does not contain a 'flake.nix'`. Per your comment on the issue, this documents the requirement rather than changing path-resolution behavior (which you flagged as risky re: other setups).

## How this was tested

Docs-only change plus a one-line help-text addition inside the existing heredoc in `pkgs/microvm-command.nix` — no logic touched. I don't have `nix` available in my sandbox to build `.#doc` locally, so I eyeballed the heredoc/markdown for syntax correctness; happy for CI to confirm.

Closes #538

---

**AI disclosure:** This PR (diff, commit message, and this description) was authored by an AI coding agent (Claude). I found no CONTRIBUTING.md or AI-usage policy in this repo to check against.
