### PR TITLE
crosvm: add platform VFIO devices

### DIFF
--- a/checks/crosvm-platform.nix
+++ b/checks/crosvm-platform.nix
@@ -1,0 +1,84 @@
+{ self, nixpkgs, system, ... }:
+
+let
+  inherit (nixpkgs) lib;
+  pkgs = nixpkgs.legacyPackages.${system};
+
+  makeConfig = modules: lib.nixosSystem {
+    inherit system;
+    modules = [
+      self.nixosModules.microvm
+      {
+        networking.hostName = "crosvm-platform-test";
+        system.stateVersion = "25.11";
+        microvm = {
+          hypervisor = "crosvm";
+          vsock.cid = 77;
+        };
+      }
+    ] ++ modules;
+  };
+
+  valid = makeConfig [{
+    microvm = {
+      crosvm.deviceTreeOverlays = [ "overlay file.dtbo" ];
+      devices = [
+        {
+          bus = "platform";
+          path = "6800000.ethernet test";
+          crosvm.dtSymbol = "mgbe0";
+        }
+        {
+          bus = "pci";
+          path = "0000:01:00.0";
+          crosvm.guestAddress = "00:1f.0";
+        }
+      ];
+    };
+  }];
+
+  runner = import ../lib/runners/crosvm.nix {
+    inherit pkgs;
+    microvmConfig = valid.config.microvm;
+    macvtapFds = { };
+    linuxTarget = pkgs.linux.target or pkgs.stdenv.hostPlatform.linux-kernel.target;
+  };
+
+  assertionsPass = nixos:
+    builtins.all ({ assertion, ... }: assertion) nixos.config.assertions;
+  missingSymbol = makeConfig [{
+    microvm = {
+      crosvm.deviceTreeOverlays = [ "overlay.dtbo" ];
+      devices = [{ bus = "platform"; path = "6800000.ethernet"; }];
+    };
+  }];
+  missingOverlay = makeConfig [{
+    microvm.devices = [{
+      bus = "platform";
+      path = "6800000.ethernet";
+      crosvm.dtSymbol = "mgbe0";
+    }];
+  }];
+  unsupportedHypervisor = makeConfig [{
+    microvm = {
+      hypervisor = lib.mkForce "qemu";
+      crosvm.deviceTreeOverlays = [ "overlay.dtbo" ];
+      devices = [{
+        bus = "platform";
+        path = "6800000.ethernet";
+        crosvm.dtSymbol = "mgbe0";
+      }];
+    };
+  }];
+in
+lib.optionalAttrs (lib.hasSuffix "-linux" system) {
+  crosvm-platform-devices =
+    assert lib.hasInfix "--device-tree-overlay 'overlay file.dtbo'" runner.command;
+    assert lib.hasInfix "'/sys/bus/platform/devices/6800000.ethernet test,iommu=off,dt-symbol=mgbe0'" runner.command;
+    assert lib.hasInfix "/sys/bus/pci/devices/0000:01:00.0,iommu=viommu,guest-address=00:1f.0" runner.command;
+    assert assertionsPass valid;
+    assert !assertionsPass missingSymbol;
+    assert !assertionsPass missingOverlay;
+    assert !assertionsPass unsupportedHypervisor;
+    pkgs.runCommand "crosvm-platform-devices" { } "touch $out";
+}

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -252,6 +252,7 @@ let
 in
 import ./shellcheck.nix args //
 import ./microvm-command.nix args //
+import ./crosvm-platform.nix args //
 import ./imperative-template.nix args //
 import ./startup-shutdown.nix args //
 import ./shutdown-command.nix args //

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -12,7 +12,7 @@ let
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem user volumes shares
     socket devices vsock graphics credentialFiles
     kernel initrdPath storeDisk storeOnDisk;
-  inherit (microvmConfig.crosvm) pivotRoot extraArgs;
+  inherit (microvmConfig.crosvm) pivotRoot extraArgs deviceTreeOverlays;
 
   crosvmPkg = microvmConfig.crosvm.package;
 
@@ -136,14 +136,26 @@ in {
         "--vsock" (toString vsock.cid)
       ]
       ++
+      builtins.concatMap (overlay: [
+        "--device-tree-overlay"
+        overlay
+      ]) deviceTreeOverlays
+      ++
       [
         "--initrd" initrdPath
         kernelPath
       ]
     )
-    + " " + # Move vfio-pci outside of
-      lib.concatStringsSep " " (lib.concatMap ({ bus, path, ... }: {
-        pci = [ "--vfio" "/sys/bus/pci/devices/${path},iommu=viommu" ];
+    + " " + # Keep host device paths outside of the Nix store.
+      lib.escapeShellArgs (lib.concatMap ({ bus, path, crosvm, ... }: {
+        pci = [
+          "--vfio"
+          "/sys/bus/pci/devices/${path},iommu=${crosvm.iommu}${lib.optionalString (crosvm.guestAddress != null) ",guest-address=${crosvm.guestAddress}"}${lib.optionalString (crosvm.dtSymbol != null) ",dt-symbol=${crosvm.dtSymbol}"}"
+        ];
+        platform = [
+          "--vfio"
+          "/sys/bus/platform/devices/${path},iommu=${crosvm.iommu},dt-symbol=${crosvm.dtSymbol}"
+        ];
         usb = throw "USB passthrough is not supported on crosvm";
       }.${bus}) devices)
     + " " + lib.escapeShellArgs extraArgs;

--- a/nixos-modules/microvm/asserts.nix
+++ b/nixos-modules/microvm/asserts.nix
@@ -114,6 +114,43 @@ lib.mkIf config.microvm.guest.enable {
         config.microvm.shares
     )
     ++
+    # platform device passthrough requires Crosvm's DT overlay plumbing
+    map ({ path, ... }: {
+      assertion = config.microvm.hypervisor == "crosvm";
+      message = ''
+        MicroVM ${hostName}: platform device "${path}" is only supported with crosvm.
+      '';
+    }) (
+      builtins.filter ({ bus, ... }: bus == "platform") config.microvm.devices
+    )
+    ++
+    map ({ path, crosvm, ... }: {
+      assertion = crosvm.dtSymbol != null;
+      message = ''
+        MicroVM ${hostName}: platform device "${path}" requires `crosvm.dtSymbol`.
+      '';
+    }) (
+      builtins.filter ({ bus, ... }: bus == "platform") config.microvm.devices
+    )
+    ++
+    [ {
+      assertion =
+        !(builtins.any ({ bus, ... }: bus == "platform") config.microvm.devices)
+        || config.microvm.crosvm.deviceTreeOverlays != [];
+      message = ''
+        MicroVM ${hostName}: platform devices require at least one `microvm.crosvm.deviceTreeOverlays` entry.
+      '';
+    } ]
+    ++
+    [ {
+      assertion =
+        config.microvm.crosvm.deviceTreeOverlays == []
+        || config.microvm.hypervisor == "crosvm";
+      message = ''
+        MicroVM ${hostName}: `microvm.crosvm.deviceTreeOverlays` is only supported with crosvm.
+      '';
+    } ]
+    ++
     # blacklist forwardPorts
     [ {
       assertion =

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -434,7 +434,7 @@ in
     };
 
     devices = mkOption {
-      description = "PCI/USB devices that are passed from the host to the MicroVM";
+      description = "PCI/platform/USB devices that are passed from the host to the MicroVM";
       default = [];
       example = literalExpression /* nix */ ''
         [ {
@@ -450,12 +450,12 @@ in
           path = "vendorid=0xabcd,productid=0x0123";
         } ]
       '';
-      type = with types; listOf (submodule {
+      type = with types; listOf (submodule ({ config, ... }: {
         options = {
           bus = mkOption {
-            type = enum [ "pci" "usb" ];
+            type = enum [ "pci" "platform" "usb" ];
             description = ''
-              Device is either on the `pci` or the `usb` bus
+              Bus that identifies the host device.
             '';
           };
           path = mkOption {
@@ -487,8 +487,31 @@ in
               '';
             };
           };
+          crosvm.dtSymbol = mkOption {
+            type = nullOr str;
+            default = null;
+            description = ''
+              Device-tree symbol that labels this device in a Crosvm overlay.
+              This is required for platform devices.
+            '';
+          };
+          crosvm.guestAddress = mkOption {
+            type = nullOr str;
+            default = null;
+            description = ''
+              PCI address assigned to this device in the Crosvm guest.
+              This is useful when the host PCI domain cannot be represented
+              in Crosvm's guest PCI topology.
+            '';
+          };
+          crosvm.iommu = mkOption {
+            type = enum [ "off" "viommu" "coiommu" "pkvm-iommu" ];
+            default = if config.bus == "platform" then "off" else "viommu";
+            defaultText = literalExpression ''if config.bus == "platform" then "off" else "viommu"'';
+            description = "Crosvm IOMMU mode for this device.";
+          };
         };
-      });
+      }));
     };
 
     vsock.cid = mkOption {
@@ -816,6 +839,12 @@ in
       type = with types; listOf str;
       default = [];
       description = "Extra arguments to pass to crosvm.";
+    };
+
+    crosvm.deviceTreeOverlays = mkOption {
+      type = with types; listOf str;
+      default = [];
+      description = "Device-tree overlay filenames passed to Crosvm.";
     };
 
     crosvm.pivotRoot = mkOption {


### PR DESCRIPTION
## Summary

- add typed Crosvm platform VFIO devices with required device-tree symbols
- add per-device Crosvm IOMMU modes, preserving `viommu` for PCI and defaulting platform devices to `off`
- add guest PCI address selection and device-tree overlay arguments
- reject platform devices on other hypervisors and incomplete overlay configurations
- test argument quoting, PCI compatibility, and assertion failures


